### PR TITLE
feat: add ControllerManager for managing active routes and collections

### DIFF
--- a/crates/mockito-core/src/controller.rs
+++ b/crates/mockito-core/src/controller.rs
@@ -1,0 +1,889 @@
+//! Controller for managing active routes and switching between collections.
+//!
+//! This module provides `ControllerManager` which manages active routes from collections
+//! and provides fast route lookup by request matching.
+
+use crate::manager::{ActiveRoute, MocksManager, ResolveError};
+use crate::matching::{
+    headers_intersects, parse_query_string, payload_matches, query_matches, url_matches,
+};
+use crate::types::preset::Preset;
+use crate::types::route::{HttpMethod, Transport};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// HTTP request for route matching
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Request {
+    /// Request URL (path + query string)
+    pub url: String,
+    /// HTTP method
+    pub method: Option<HttpMethod>,
+    /// Transport type
+    pub transport: Transport,
+    /// Request headers
+    pub headers: Option<HashMap<String, String>>,
+    /// Query parameters (parsed from URL or provided separately)
+    pub query: Option<HashMap<String, String>>,
+    /// Request body/payload (for POST/PUT/PATCH)
+    pub payload: Option<Value>,
+}
+
+/// Manager for controlling active routes and collection switching.
+///
+/// `ControllerManager` provides:
+/// - Collection activation via `use_collection()`
+/// - Fast route lookup via `find_route()`
+/// - Cached active routes for performance
+/// - Request matching against route presets
+#[derive(Debug, Clone)]
+pub struct ControllerManager {
+    /// Mocks manager for storing and resolving collections/routes
+    mocks_manager: MocksManager,
+    /// Currently active collection ID
+    active_collection_id: Option<String>,
+    /// Cached active routes from the current collection
+    cached_active_routes: Vec<ActiveRoute>,
+}
+
+impl ControllerManager {
+    /// Create a new ControllerManager with MocksManager.
+    ///
+    /// The controller consumes the manager and uses its data as the source for route resolution.
+    /// Data from the manager is read-only - routes and collections should be added to MocksManager
+    /// before passing it to the controller.
+    pub fn new(mocks_manager: MocksManager) -> Self {
+        Self {
+            mocks_manager,
+            active_collection_id: None,
+            cached_active_routes: Vec::new(),
+        }
+    }
+
+    /// Activate a collection by ID.
+    ///
+    /// This resolves the collection and caches the active routes for fast lookup.
+    /// Returns error if collection not found or resolution fails.
+    pub fn use_collection(&mut self, collection_id: &str) -> Result<(), ResolveError> {
+        let active_routes = self.mocks_manager.resolve_collection(collection_id)?;
+        self.active_collection_id = Some(collection_id.to_string());
+        self.cached_active_routes = active_routes;
+        Ok(())
+    }
+
+    /// Get all currently active routes.
+    ///
+    /// Returns cached active routes from the current collection.
+    pub fn get_active_routes(&self) -> &[ActiveRoute] {
+        &self.cached_active_routes
+    }
+
+    /// Get currently active collection ID
+    pub fn active_collection_id(&self) -> Option<&str> {
+        self.active_collection_id.as_deref()
+    }
+
+    /// Find a route that matches the given request.
+    ///
+    /// Searches through cached active routes and returns the first matching route.
+    /// Matching is performed in order: URL, method, transport, headers, query, payload.
+    ///
+    /// Returns `None` if no matching route is found.
+    pub fn find_route(&self, request: &Request) -> Option<&ActiveRoute> {
+        self.cached_active_routes
+            .iter()
+            .find(|active_route| self.route_matches_request(active_route, request))
+    }
+
+    /// Check if an active route matches the given request
+    fn route_matches_request(&self, active_route: &ActiveRoute, request: &Request) -> bool {
+        let route = &active_route.route;
+        let preset = &active_route.preset;
+
+        // Check transport
+        if route.transport != request.transport {
+            return false;
+        }
+
+        // Check HTTP method (for HTTP routes)
+        if route.transport == Transport::Http {
+            if let Some(route_method) = &route.method {
+                if let Some(request_method) = &request.method {
+                    if route_method != request_method {
+                        return false;
+                    }
+                } else {
+                    return false; // Route requires method but request doesn't have it
+                }
+            }
+        }
+
+        // Check URL pattern
+        let url_result = url_matches(&route.url, &request.url);
+        if !url_result.matched {
+            return false;
+        }
+
+        // Check URL path parameters (from preset.params)
+        if let Some(expected_params) = &preset.params {
+            // URL params are extracted from URL pattern matching
+            // Check if all expected params are present in matched params
+            for (key, expected_value) in expected_params {
+                if let Some(actual_value) = url_result.params.get(key) {
+                    if actual_value != expected_value {
+                        return false;
+                    }
+                } else {
+                    return false; // Expected param not found
+                }
+            }
+        }
+
+        // Check headers
+        if !headers_intersects(request.headers.as_ref(), preset.headers.as_ref()) {
+            return false;
+        }
+
+        // Check query parameters
+        let request_query = if let Some(query) = request.query.as_ref() {
+            query
+        } else {
+            // Parse query from URL if not provided separately
+            let parsed_query = if let Some(query_str) = request.url.split('?').nth(1) {
+                parse_query_string(query_str)
+            } else {
+                HashMap::new()
+            };
+            // Use helper method to avoid lifetime issues with temporary
+            if !self.check_query_with_parsed(preset, Some(&parsed_query)) {
+                return false;
+            }
+            // Continue to payload check
+            return self.check_payload(preset, &request.payload);
+        };
+
+        if !query_matches(
+            preset.query.as_ref(),
+            preset.query_expr.as_deref(),
+            request_query,
+        ) {
+            return false;
+        }
+
+        // Check payload/body
+        self.check_payload(preset, &request.payload)
+    }
+
+    /// Helper method to check query with parsed query from URL
+    fn check_query_with_parsed(
+        &self,
+        preset: &Preset,
+        parsed_query: Option<&HashMap<String, String>>,
+    ) -> bool {
+        let empty_query = HashMap::new();
+        query_matches(
+            preset.query.as_ref(),
+            preset.query_expr.as_deref(),
+            parsed_query.unwrap_or(&empty_query),
+        )
+    }
+
+    /// Helper method to check payload
+    fn check_payload(&self, preset: &Preset, request_payload: &Option<Value>) -> bool {
+        if let Some(request_payload) = request_payload {
+            payload_matches(
+                preset.payload.as_ref(),
+                preset.payload_expr.as_deref(),
+                request_payload,
+            )
+        } else if preset.payload.is_some() || preset.payload_expr.is_some() {
+            // Preset expects payload but request doesn't have it
+            false
+        } else {
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::collection::Collection;
+    use crate::types::preset::Preset;
+    use crate::types::route::{HttpMethod, Route, Transport};
+    use crate::types::variant::Variant;
+    use rstest::rstest;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn create_test_route(id: &str, url: &str) -> Route {
+        Route {
+            id: id.to_string(),
+            url: url.to_string(),
+            transport: Transport::Http,
+            method: Some(HttpMethod::Get),
+            presets: vec![],
+        }
+    }
+
+    fn create_test_preset(id: &str) -> Preset {
+        Preset {
+            id: id.to_string(),
+            params: None,
+            query: None,
+            query_expr: None,
+            headers: None,
+            payload: None,
+            payload_expr: None,
+            variants: vec![],
+        }
+    }
+
+    fn create_test_variant(id: &str) -> Variant {
+        Variant {
+            id: id.to_string(),
+            status: Some(200),
+            headers: None,
+            body: None,
+        }
+    }
+
+    #[rstest]
+    fn test_controller_manager_new() {
+        let manager = MocksManager::new();
+        let controller = ControllerManager::new(manager);
+        assert_eq!(controller.active_collection_id(), None);
+        assert_eq!(controller.get_active_routes().len(), 0);
+    }
+
+    #[rstest]
+    fn test_use_collection() {
+        // Create manager and add routes/collections
+        let mut manager = MocksManager::new();
+        let mut route = create_test_route("route1", "/api/users");
+        let mut preset = create_test_preset("preset1");
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+
+        // Create controller with manager
+        let mut controller = ControllerManager::new(manager);
+
+        // Activate collection
+        let result = controller.use_collection("collection1");
+        assert!(result.is_ok());
+        assert_eq!(controller.active_collection_id(), Some("collection1"));
+        assert_eq!(controller.get_active_routes().len(), 1);
+    }
+
+    #[rstest]
+    fn test_use_collection_not_found() {
+        let manager = MocksManager::new();
+        let mut controller = ControllerManager::new(manager);
+        let result = controller.use_collection("nonexistent");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ResolveError::CollectionNotFound { .. }
+        ));
+    }
+
+    #[rstest]
+    fn test_get_active_routes() {
+        let mut manager = MocksManager::new();
+
+        // Create routes
+        let mut route1 = create_test_route("route1", "/api/users");
+        let mut preset1 = create_test_preset("preset1");
+        preset1.variants.push(create_test_variant("variant1"));
+        route1.presets.push(preset1);
+        manager.add_route(route1);
+
+        let mut route2 = create_test_route("route2", "/api/posts");
+        let mut preset2 = create_test_preset("preset2");
+        preset2.variants.push(create_test_variant("variant2"));
+        route2.presets.push(preset2);
+        manager.add_route(route2);
+
+        // Create collection
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec![
+                "route1:preset1:variant1".to_string(),
+                "route2:preset2:variant2".to_string(),
+            ],
+        };
+        manager.add_collection(collection);
+
+        // Activate collection
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Get active routes
+        let active_routes = controller.get_active_routes();
+        assert_eq!(active_routes.len(), 2);
+        assert_eq!(active_routes[0].route.id, "route1");
+        assert_eq!(active_routes[1].route.id, "route2");
+    }
+
+    #[rstest]
+    fn test_find_route_by_url() {
+        let mut manager = MocksManager::new();
+
+        // Create route
+        let mut route = create_test_route("route1", "/api/users");
+        let mut preset = create_test_preset("preset1");
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        // Create collection
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+
+        // Activate collection
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Find route
+        let request = Request {
+            url: "/api/users".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().route.id, "route1");
+    }
+
+    #[rstest]
+    fn test_find_route_with_url_params() {
+        let mut manager = MocksManager::new();
+
+        // Create route with URL params
+        let mut route = create_test_route("route1", "/api/users/{id}");
+        let mut preset = create_test_preset("preset1");
+        let mut params = HashMap::new();
+        params.insert("id".to_string(), "123".to_string());
+        preset.params = Some(params);
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        // Create collection
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+
+        // Activate collection
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Find route with matching params
+        let request = Request {
+            url: "/api/users/123".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_some());
+
+        // Find route with non-matching params
+        let request = Request {
+            url: "/api/users/456".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_find_route_with_headers() {
+        let mut manager = MocksManager::new();
+
+        // Create route with headers
+        let mut route = create_test_route("route1", "/api/users");
+        let mut preset = create_test_preset("preset1");
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer token".to_string());
+        preset.headers = Some(headers);
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        // Create collection
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+
+        // Activate collection
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Find route with matching headers
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer token".to_string());
+        let request = Request {
+            url: "/api/users".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: Some(headers),
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_some());
+
+        // Find route with non-matching headers
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer wrong".to_string());
+        let request = Request {
+            url: "/api/users".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: Some(headers),
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_find_route_with_query() {
+        let mut manager = MocksManager::new();
+
+        // Create route with query
+        let mut route = create_test_route("route1", "/api/users");
+        let mut preset = create_test_preset("preset1");
+        let mut query = HashMap::new();
+        query.insert("page".to_string(), "1".to_string());
+        preset.query = Some(query);
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        // Create collection
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+
+        // Activate collection
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Find route with matching query
+        let mut query = HashMap::new();
+        query.insert("page".to_string(), "1".to_string());
+        let request = Request {
+            url: "/api/users?page=1".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: None,
+            query: None, // Will be parsed from URL
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_some());
+
+        // Find route with non-matching query
+        let request = Request {
+            url: "/api/users?page=2".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_find_route_with_payload() {
+        let mut manager = MocksManager::new();
+
+        // Create route with payload
+        let mut route = create_test_route("route1", "/api/users");
+        route.method = Some(HttpMethod::Post);
+        let mut preset = create_test_preset("preset1");
+        let mut payload = HashMap::new();
+        payload.insert("name".to_string(), json!("John"));
+        preset.payload = Some(payload);
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        // Create collection
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+
+        // Activate collection
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Find route with matching payload
+        let request = Request {
+            url: "/api/users".to_string(),
+            method: Some(HttpMethod::Post),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: Some(json!({"name": "John"})),
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_some());
+
+        // Find route with non-matching payload
+        let request = Request {
+            url: "/api/users".to_string(),
+            method: Some(HttpMethod::Post),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: Some(json!({"name": "Jane"})),
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_find_route_not_found() {
+        let mut manager = MocksManager::new();
+
+        // Create route
+        let mut route = create_test_route("route1", "/api/users");
+        let mut preset = create_test_preset("preset1");
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        // Create collection
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+
+        // Activate collection
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Find route that doesn't exist
+        let request = Request {
+            url: "/api/posts".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_switch_collections() {
+        let mut manager = MocksManager::new();
+
+        // Create routes
+        let mut route1 = create_test_route("route1", "/api/users");
+        let mut preset1 = create_test_preset("preset1");
+        preset1.variants.push(create_test_variant("variant1"));
+        route1.presets.push(preset1);
+        manager.add_route(route1);
+
+        let mut route2 = create_test_route("route2", "/api/posts");
+        let mut preset2 = create_test_preset("preset2");
+        preset2.variants.push(create_test_variant("variant2"));
+        route2.presets.push(preset2);
+        manager.add_route(route2);
+
+        // Create collections
+        let collection1 = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection1);
+
+        let collection2 = Collection {
+            id: "collection2".to_string(),
+            from: None,
+            routes: vec!["route2:preset2:variant2".to_string()],
+        };
+        manager.add_collection(collection2);
+
+        // Activate first collection
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+        assert_eq!(controller.get_active_routes().len(), 1);
+        assert_eq!(controller.get_active_routes()[0].route.id, "route1");
+
+        // Switch to second collection
+        controller.use_collection("collection2").unwrap();
+        assert_eq!(controller.get_active_routes().len(), 1);
+        assert_eq!(controller.get_active_routes()[0].route.id, "route2");
+    }
+
+    #[rstest]
+    fn test_controller_manager_with_manager() {
+        let mut manager = MocksManager::new();
+        let mut route = create_test_route("route1", "/api/users");
+        let mut preset = create_test_preset("preset1");
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+
+        let mut controller = ControllerManager::new(manager);
+        assert_eq!(controller.active_collection_id(), None);
+        assert_eq!(controller.get_active_routes().len(), 0);
+
+        // Activate collection to verify manager data is used
+        controller.use_collection("collection1").unwrap();
+        assert_eq!(controller.get_active_routes().len(), 1);
+        assert_eq!(controller.get_active_routes()[0].route.id, "route1");
+    }
+
+    #[rstest]
+    fn test_find_route_transport_mismatch() {
+        let mut manager = MocksManager::new();
+
+        // Create WebSocket route
+        let mut route = Route {
+            id: "route1".to_string(),
+            url: "/ws".to_string(),
+            transport: Transport::WebSocket,
+            method: None,
+            presets: vec![],
+        };
+        let mut preset = create_test_preset("preset1");
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Try to find with HTTP transport
+        let request = Request {
+            url: "/ws".to_string(),
+            method: None,
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_find_route_method_required_but_missing() {
+        let mut manager = MocksManager::new();
+
+        // Create route with required method
+        let mut route = create_test_route("route1", "/api/users");
+        route.method = Some(HttpMethod::Post);
+        let mut preset = create_test_preset("preset1");
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Request without method
+        let request = Request {
+            url: "/api/users".to_string(),
+            method: None,
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_find_route_method_mismatch() {
+        let mut manager = MocksManager::new();
+
+        // Create POST route
+        let mut route = create_test_route("route1", "/api/users");
+        route.method = Some(HttpMethod::Post);
+        let mut preset = create_test_preset("preset1");
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Request with GET method
+        let request = Request {
+            url: "/api/users".to_string(),
+            method: Some(HttpMethod::Get),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_find_route_payload_required_but_missing() {
+        let mut manager = MocksManager::new();
+
+        // Create route with required payload
+        let mut route = create_test_route("route1", "/api/users");
+        route.method = Some(HttpMethod::Post);
+        let mut preset = create_test_preset("preset1");
+        let mut payload = HashMap::new();
+        payload.insert("name".to_string(), json!("John"));
+        preset.payload = Some(payload);
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Request without payload
+        let request = Request {
+            url: "/api/users".to_string(),
+            method: Some(HttpMethod::Post),
+            transport: Transport::Http,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_none());
+    }
+
+    #[rstest]
+    fn test_find_route_websocket() {
+        let mut manager = MocksManager::new();
+
+        // Create WebSocket route
+        let mut route = Route {
+            id: "route1".to_string(),
+            url: "/ws".to_string(),
+            transport: Transport::WebSocket,
+            method: None,
+            presets: vec![],
+        };
+        let mut preset = create_test_preset("preset1");
+        preset.variants.push(create_test_variant("variant1"));
+        route.presets.push(preset);
+        manager.add_route(route);
+
+        let collection = Collection {
+            id: "collection1".to_string(),
+            from: None,
+            routes: vec!["route1:preset1:variant1".to_string()],
+        };
+        manager.add_collection(collection);
+        let mut controller = ControllerManager::new(manager);
+        controller.use_collection("collection1").unwrap();
+
+        // Find WebSocket route
+        let request = Request {
+            url: "/ws".to_string(),
+            method: None,
+            transport: Transport::WebSocket,
+            headers: None,
+            query: None,
+            payload: None,
+        };
+
+        let found = controller.find_route(&request);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().route.id, "route1");
+    }
+}

--- a/crates/mockito-core/src/lib.rs
+++ b/crates/mockito-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Mockito core library
 
 pub mod config;
+pub mod controller;
 pub mod expression;
 pub mod manager;
 pub mod matching;

--- a/crates/mockito-core/src/manager.rs
+++ b/crates/mockito-core/src/manager.rs
@@ -1,8 +1,8 @@
 //! Mocks manager for managing routes and collections.
 //!
 //! This module provides `MocksManager` which stores and resolves collections and routes.
-//! It will be used by `MocksController` (to be implemented) for handling dynamic
-//! changes to mocked routes from added collections/routes.
+//! It is used by `ControllerManager` for handling dynamic changes to mocked routes
+//! from added collections/routes.
 
 use crate::types::collection::Collection;
 use crate::types::preset::Preset;
@@ -30,7 +30,7 @@ pub struct ActiveRoute {
 /// - Detecting circular dependencies
 /// - Merging routes (child collections override parent routes)
 ///
-/// This manager will be used by `MocksController` to handle dynamic changes
+/// This manager is used by `ControllerManager` to handle dynamic changes
 /// to mocked routes from added collections/routes.
 #[derive(Debug, Clone)]
 pub struct MocksManager {


### PR DESCRIPTION
- Implement ControllerManager for managing active routes and switching between collections
- Add use_collection() to activate collection and cache routes
- Add get_active_routes() to get currently active routes
- Add find_route() to find matching route by request
- Cache active routes for performance
- Simplify API: remove new() without parameters, rename with_manager to new
- Remove Default implementation for ControllerManager
- Update comments in manager.rs: remove mentions of future controller implementation
- Fix clippy warning: replace manual loop with Iterator::find