### PR TITLE
feat: allow any type for payload in preset and body in variant

### DIFF
--- a/crates/mockito-core/src/mocks/controller.rs
+++ b/crates/mockito-core/src/mocks/controller.rs
@@ -552,9 +552,7 @@ mod tests {
         let mut route = create_test_route("route1", "/api/users");
         route.method = Some(HttpMethod::Post);
         let mut preset = create_test_preset("preset1");
-        let mut payload = HashMap::new();
-        payload.insert("name".to_string(), json!("John"));
-        preset.payload = Some(payload);
+        preset.payload = Some(json!({"name": "John"}));
         preset.variants.push(create_test_variant("variant1"));
         route.presets.push(preset);
         manager.add_route(route);
@@ -823,9 +821,7 @@ mod tests {
         let mut route = create_test_route("route1", "/api/users");
         route.method = Some(HttpMethod::Post);
         let mut preset = create_test_preset("preset1");
-        let mut payload = HashMap::new();
-        payload.insert("name".to_string(), json!("John"));
-        preset.payload = Some(payload);
+        preset.payload = Some(json!({"name": "John"}));
         preset.variants.push(create_test_variant("variant1"));
         route.presets.push(preset);
         manager.add_route(route);

--- a/crates/mockito-core/src/types/preset.rs
+++ b/crates/mockito-core/src/types/preset.rs
@@ -23,7 +23,7 @@ pub struct Preset {
     pub headers: Option<HashMap<String, String>>,
     /// Request body to match (for POST/PUT/PATCH)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payload: Option<HashMap<String, serde_json::Value>>,
+    pub payload: Option<serde_json::Value>,
     /// JMESPath expression for complex body matching (alternative to payload)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload_expr: Option<String>,
@@ -57,11 +57,7 @@ mod tests {
                 map.insert("Authorization".to_string(), "Bearer token".to_string());
                 map
             }),
-            payload: Some({
-                let mut map = HashMap::new();
-                map.insert("name".to_string(), json!("John"));
-                map
-            }),
+            payload: Some(json!({"name": "John"})),
             payload_expr: None,
             query_expr: None,
             variants: vec![],

--- a/crates/mockito-napi/src/config.rs
+++ b/crates/mockito-napi/src/config.rs
@@ -131,9 +131,7 @@ impl From<CorePreset> for Preset {
             query: p.query,
             query_expr: p.query_expr,
             params: p.params,
-            payload: p
-                .payload
-                .map(|h| serde_json::to_value(h).unwrap_or_default()),
+            payload: p.payload,
             payload_expr: p.payload_expr,
         }
     }
@@ -148,10 +146,7 @@ impl From<&CorePreset> for Preset {
             query: p.query.clone(),
             query_expr: p.query_expr.clone(),
             params: p.params.clone(),
-            payload: p
-                .payload
-                .as_ref()
-                .map(|h| serde_json::to_value(h).unwrap_or_default()),
+            payload: p.payload.clone(),
             payload_expr: p.payload_expr.clone(),
         }
     }
@@ -227,7 +222,7 @@ impl From<Preset> for CorePreset {
             query: p.query,
             query_expr: p.query_expr,
             params: p.params,
-            payload: p.payload.and_then(|v| serde_json::from_value(v).ok()),
+            payload: p.payload,
             payload_expr: p.payload_expr,
         }
     }
@@ -242,10 +237,7 @@ impl From<&Preset> for CorePreset {
             query: p.query.clone(),
             query_expr: p.query_expr.clone(),
             params: p.params.clone(),
-            payload: p
-                .payload
-                .as_ref()
-                .and_then(|v| serde_json::from_value(v.clone()).ok()),
+            payload: p.payload.clone(),
             payload_expr: p.payload_expr.clone(),
         }
     }


### PR DESCRIPTION
- Changed Preset.payload from HashMap<String, Value> to Value to support any JSON type
- Updated payload_matches to handle objects (intersection) and other types (direct comparison)
- Simplified NAPI binding conversion logic
- Added tests for string, number, array, boolean, and null payload types
- TypeScript types already use 'any' for both payload and body