### PR TITLE
feat: unify value and expression fields in preset

### DIFF
--- a/bindings/node_binding/binding.d.ts
+++ b/bindings/node_binding/binding.d.ts
@@ -59,12 +59,13 @@ export declare const enum HttpMethod {
 export interface Preset {
   id: string
   variants: Array<Variant>
-  headers?: Record<string, string>
-  query?: Record<string, string>
-  queryExpr?: string
+  /** Headers to match (can be an object or expression string like "${headers.myheader == 1}") */
+  headers?: any
+  /** Query parameters to match (can be an object or expression string like "${query.page == '1'}") */
+  query?: any
   params?: Record<string, string>
+  /** Payload to match (can be any JSON value or expression string like "${payload.items[0].id == 5}") */
   payload?: any
-  payloadExpr?: string
 }
 
 /** Route definition */

--- a/crates/mockito-core/src/expression.rs
+++ b/crates/mockito-core/src/expression.rs
@@ -4,6 +4,11 @@ use jmespath::Variable;
 use serde_json::Value;
 use std::rc::Rc;
 
+/// Check if a string is an expression (starts with ${ and ends with })
+pub fn is_expression(s: &str) -> bool {
+    s.starts_with("${") && s.ends_with('}')
+}
+
 /// Convert serde_json::Value to jmespath::Variable.
 pub fn value_to_variable(value: &Value) -> Rc<Variable> {
     match value {
@@ -206,5 +211,20 @@ mod tests {
             ]
         });
         assert_eq!(evaluate_jmespath(expression, &data), expected);
+    }
+
+    #[rstest]
+    #[case("${expression}", true)]
+    #[case("${query.page == '1'}", true)]
+    #[case("${headers.myheader == 1}", true)]
+    #[case("${payload.items[0].id == 5}", true)]
+    #[case("expression", false)]
+    #[case("${expression", false)]
+    #[case("expression}", false)]
+    #[case("${}", true)]
+    #[case("", false)]
+    #[case("${expression} extra", false)]
+    fn test_is_expression(#[case] s: &str, #[case] expected: bool) {
+        assert_eq!(is_expression(s), expected);
     }
 }

--- a/crates/mockito-core/src/matching/headers.rs
+++ b/crates/mockito-core/src/matching/headers.rs
@@ -1,5 +1,8 @@
-//! Headers intersection check (case-insensitive).
+//! Headers intersection check (case-insensitive) and JMESPath expressions.
 
+use crate::expression::match_with_jmespath;
+use crate::matching::intersection::hashmap_to_value;
+use crate::types::preset::HeadersOrExpression;
 use std::collections::HashMap;
 
 fn normalize_headers(headers: Option<&HashMap<String, String>>) -> HashMap<String, String> {
@@ -31,6 +34,33 @@ pub fn headers_intersects(
     let subset = normalize_headers(Some(subset));
 
     subset.iter().all(|(k, v)| target.get(k) == Some(v))
+}
+
+/// Match headers using JMESPath expression.
+fn match_headers_with_expression(expression: &str, headers: &HashMap<String, String>) -> bool {
+    let headers_json = hashmap_to_value(headers);
+    match_with_jmespath(expression, &headers_json)
+}
+
+/// Match headers using either HashMap intersection or JMESPath expression.
+pub fn headers_matches(
+    expected: Option<&HeadersOrExpression>,
+    actual: &HashMap<String, String>,
+) -> bool {
+    match expected {
+        Some(HeadersOrExpression::Expression(expr)) => {
+            // Use JMESPath expression
+            match_headers_with_expression(expr, actual)
+        }
+        Some(HeadersOrExpression::Map(expected_map)) => {
+            // Use HashMap intersection
+            headers_intersects(Some(actual), Some(expected_map))
+        }
+        None => {
+            // No headers specified = match any actual
+            true
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/mockito-core/src/matching/mod.rs
+++ b/crates/mockito-core/src/matching/mod.rs
@@ -6,7 +6,7 @@ mod payload;
 mod query;
 mod url;
 
-pub use headers::headers_intersects;
+pub use headers::{headers_intersects, headers_matches};
 pub use intersection::{hashmap_intersects, object_intersects};
 pub use payload::payload_matches;
 pub use query::{parse_query_string, query_matches};

--- a/crates/mockito-core/src/mocks/manager.rs
+++ b/crates/mockito-core/src/mocks/manager.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, HashSet};
 /// Active route with selected preset and variant.
 ///
 /// Represents a fully resolved route that can be used for mocking.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ActiveRoute {
     /// Base route definition
     pub route: Route,
@@ -323,10 +323,8 @@ mod tests {
             id: id.to_string(),
             params: None,
             query: None,
-            query_expr: None,
             headers: None,
             payload: None,
-            payload_expr: None,
             variants: vec![],
         }
     }

--- a/crates/mockito-core/src/types/route.rs
+++ b/crates/mockito-core/src/types/route.rs
@@ -25,7 +25,7 @@ pub enum HttpMethod {
 }
 
 /// Mock route definition.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Route {
     /// Unique identifier for this route
     pub id: String,


### PR DESCRIPTION
BREAKING CHANGE: Removed separate *_expr fields, now use same field for values and expressions

Major refactoring to simplify preset configuration by allowing the same field to accept both values and expressions (using `${expression}` syntax).

Core changes:
- Created enum types: QueryOrExpression, HeadersOrExpression, PayloadOrExpression
- Removed query_expr and payload_expr fields from Preset
- Updated query, headers, and payload fields to support both values and expressions
- Expression format: `${expression}` (e.g., `${query.page == '1'}`)
- Value format: normal JSON values (objects, arrays, primitives)

Matching logic:
- Updated payload_matches to work with PayloadOrExpression
- Updated query_matches to work with QueryOrExpression
- Added headers_matches function with expression support
- All matching functions now handle both values and expressions automatically

NAPI bindings:
- Updated Preset struct to use serde_json::Value for query/headers/payload
- Added automatic conversion between Value and *OrExpression types
- Expression detection based on `${...}` pattern

Code organization:
- Moved is_expression function to expression module
- Updated all imports to use expression::is_expression
- Added comprehensive tests for is_expression

Type changes:
- Preset no longer implements Eq (due to PayloadOrExpression containing Value)
- Route no longer implements Eq (due to containing Preset)
- ActiveRoute no longer implements Eq

All 274 tests passing