### PR TITLE
feat: add e2e tests package

### DIFF
--- a/bindings/node_binding/package.json
+++ b/bindings/node_binding/package.json
@@ -30,8 +30,8 @@
   "scripts": {
     "artifacts": "napi artifacts",
     "prepack": "napi prepublish --tag-style npm --skip-optional-publish && node scripts/copy-readme.js",
-    "build": "napi build --manifest-path ../../crates/mockito-napi/Cargo.toml --const-enum --platform -p mockito-napi --js ./binding.js --dts ./binding.d.ts --release -o .",
-    "build:dev": "napi build --manifest-path ../../crates/mockito-napi/Cargo.toml --const-enum --platform -p mockito-napi --js ./binding.js --dts ./binding.d.ts -o ."
+    "build": "napi build --manifest-path ../../crates/mockito-napi/Cargo.toml --platform -p mockito-napi --js ./binding.js --dts ./binding.d.ts --release -o .",
+    "build:dev": "napi build --manifest-path ../../crates/mockito-napi/Cargo.toml --platform -p mockito-napi --js ./binding.js --dts ./binding.d.ts -o ."
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.5.1"

--- a/packages/mockito-e2e-tests/COMPARISON.md
+++ b/packages/mockito-e2e-tests/COMPARISON.md
@@ -1,0 +1,297 @@
+# Feature Comparison: example/mocker (JS) vs @mockito/binding (Rust)
+
+This document tracks feature parity between the original JavaScript implementation and the new Rust implementation.
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Implemented and tested |
+| 🚧 | Partially implemented |
+| ❌ | Not implemented yet |
+| ➖ | Not applicable / Internal |
+
+---
+
+## Controller Tests
+
+Source: `example/mocker/__specs__/controller.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | should mock selected collection | ✅ | `mocks-controller.spec.ts` - "should return active routes after selecting collection" | |
+| 2 | should throw if no collection found | ✅ | `mocks-controller.spec.ts` - "should throw error for non-existent collection" | |
+| 3 | should throw if collection have duplicated routes | ❌ | TODO: "should throw error for duplicated routes in collection" | |
+| 4 | should mock selected collection with nesting | ✅ | `mocks-controller.spec.ts` - "should return routes with inheritance resolved" | |
+| 5 | should throw if collection with nesting not found | ❌ | TODO: "should throw error for non-existent parent collection" | |
+| 6 | should throw if route in collection not found | ❌ | TODO: "should throw error if route in collection not found" | |
+| 7 | should throw if preset in collection not found | ❌ | TODO: "should throw error if preset in collection not found" | |
+| 8 | should throw if variant in collection not found | ❌ | TODO: "should throw error if variant in collection not found" | |
+| 9 | should mock selected route for default collection | ❌ | TODO: "should allow switching individual routes (useRoutes)" | Requires `useRoutes` method |
+| 10 | should throw if route not found | ❌ | TODO | Requires `useRoutes` method |
+| 11 | should throw if route is a websocket route | ❌ | TODO | Requires `useRoutes` method |
+| 12 | should throw if preset for route not found | ❌ | TODO | Requires `useRoutes` method |
+| 13 | should throw if variant for route not found | ❌ | TODO | Requires `useRoutes` method |
+| 14 | should restore mock to selected collection | ❌ | TODO: "should support resetRoutes" | Requires `resetRoutes` method |
+| 15 | should restore mock to nothing if no collection selected | ❌ | TODO | Requires `resetRoutes` method |
+| 16 | should throw if websocket route not found | ❌ | TODO | Requires `useSocket` method |
+| 17 | should throw if route is not a websocket route | ❌ | TODO | Requires `useSocket` method |
+| 18 | should throw if preset for websocket route not found | ❌ | TODO | Requires `useSocket` method |
+| 19 | should throw if variant for websocket route not found | ❌ | TODO | Requires `useSocket` method |
+| 20 | should pass parser url for websocket route | 🚧 | `mocks-controller.spec.ts` - "should return WebSocket routes" | Parser field not tested |
+
+---
+
+## Mocks Tests
+
+Source: `example/mocker/__specs__/mocks.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | should load definitions | ✅ | `MocksManager` constructor loads files | Constructor behavior |
+| 2 | should throw if more than 1 collection file | ➖ | N/A | Rust uses glob, may differ |
+| 3 | should throw if no collection found | ✅ | `edge-cases.spec.ts` - "should throw error for non-existent collections file" | |
+
+---
+
+## Loader Tests
+
+Source: `example/mocker/__specs__/loader.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | should load file based on data from ctor | ✅ | `mocks-manager.spec.ts` - body content tests | YAML parsing works |
+| 2 | should read only yaml files | ➖ | N/A | Rust may accept JSON too |
+
+---
+
+## Validation Tests
+
+Source: `example/mocker/__specs__/validation.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | should successfully validate collection | ✅ | Collections load successfully | |
+| 2 | should successfully validate routes | ✅ | Routes load successfully | |
+| 3 | should not accept collection without id | 🚧 | Not explicitly tested | Rust validation |
+| 4 | should not accept collection without routes | 🚧 | Not explicitly tested | Rust validation |
+| 5 | should not accept empty collection | 🚧 | Not explicitly tested | Rust validation |
+| 6 | should not accept route without id | 🚧 | Not explicitly tested | Rust validation |
+| 7 | should not accept route without url | 🚧 | Not explicitly tested | Rust validation |
+| 8 | should not accept route with empty presets | 🚧 | Not explicitly tested | Rust validation |
+| 9 | should not accept route with empty variants | 🚧 | Not explicitly tested | Rust validation |
+| 10 | should not accept route with incorrect http method | 🚧 | Not explicitly tested | Rust validation |
+| 11 | should not accept route with empty headers | 🚧 | Not explicitly tested | Rust validation |
+| 12 | should not accept route with empty params | 🚧 | Not explicitly tested | Rust validation |
+| 13 | should not accept route with empty query | 🚧 | Not explicitly tested | Rust validation |
+| 14 | should not accept route with empty payload | 🚧 | Not explicitly tested | Rust validation |
+| 15 | should not accept route with empty response headers | 🚧 | Not explicitly tested | Rust validation |
+| 16 | should successfully validate websocket route | ✅ | `mocks-controller.spec.ts` - WebSocket tests | |
+| 17 | should successfully validate parser field (ts) | ➖ | N/A | Parser is JS-specific |
+| 18 | should successfully validate parser field (js) | ➖ | N/A | Parser is JS-specific |
+| 19 | should fail to validate parser field (without encode) | ➖ | N/A | Parser is JS-specific |
+| 20 | should fail to validate parser field (without decode) | ➖ | N/A | Parser is JS-specific |
+| 21 | should concat path from context and file path from config | ➖ | N/A | Parser is JS-specific |
+
+---
+
+## Library Utility Tests
+
+### route-meta.ts
+
+Source: `example/mocker/lib/__specs__/route-meta.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | should split route into meta object | ➖ | Internal | Route string parsing: `route:preset:variant` |
+| 2 | should throw if route incorrect | ➖ | Internal | Error handling for malformed routes |
+| 3 | should create route identifier based on meta | ➖ | Internal | Creates `route:preset` identifier |
+
+### object-intersects.ts
+
+Source: `example/mocker/lib/__specs__/object-intersects.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | should return false if no keys found | ❌ | TODO | Request matching |
+| 2 | should return false if intersected keys have different values | ❌ | TODO | Request matching |
+| 3 | should return true if intersected keys have same values | ❌ | TODO | Request matching |
+
+### url-matches.ts
+
+Source: `example/mocker/lib/__specs__/url-matches.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | should detect if url string is template | ❌ | TODO | URL path parameters |
+| 2 | should fill url template with parameters | ❌ | TODO | URL path parameters |
+
+### get-single-expression.ts
+
+Source: `example/mocker/lib/__specs__/get-single-expression.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | should return expression for simple template | ❌ | TODO | Expression parsing `${foo}` |
+| 2 | should return undefined for template with surrounding text | ❌ | TODO | Expression parsing |
+| 3 | should return undefined for multiple expressions | ❌ | TODO | Expression parsing |
+| 4 | should return undefined for escaped expression | ❌ | TODO | Expression parsing |
+| 5 | should return undefined for plain text | ❌ | TODO | Expression parsing |
+
+### compile-template.ts
+
+Source: `example/mocker/lib/__specs__/compile-template.spec.ts`
+
+| # | Original Test | Status | E2E Test | Notes |
+|---|---------------|--------|----------|-------|
+| 1 | jmespath: should preserve string/number/object/array/boolean/null types | ❌ | TODO | JMESPath support |
+| 2 | jmespath: nested value, array element access | ❌ | TODO | JMESPath support |
+| 3 | string interpolation: interpolate string values | ❌ | TODO | Template interpolation |
+| 4 | string interpolation: handle nested object templates | ❌ | TODO | Template interpolation |
+| 5 | array templates: should compile templates inside arrays | ❌ | TODO | Template interpolation |
+| 6 | object templates: should handle multiple expressions | ❌ | TODO | Template interpolation |
+| 7 | function calls: sum, to_string, length | ❌ | TODO | JMESPath functions |
+| 8 | function calls: complex filter/project/sort/join | ❌ | TODO | JMESPath functions |
+| 9 | escaped expressions: should not evaluate escaped expressions | ❌ | TODO | `\${name}` handling |
+| 10 | context validation: should throw error when context is not JSON | ❌ | TODO | Error handling |
+| 11 | null result: should return empty string for null | ❌ | TODO | Null handling |
+
+---
+
+## Summary
+
+### E2E Test Statistics
+
+```
+Test Files: 9 passed
+Tests:      147 passed | 14 todo (161 total)
+Duration:   ~200ms
+```
+
+### Test Files
+
+| File | Tests | Description |
+|------|-------|-------------|
+| `mocks-controller.spec.ts` | 34 | Controller API, collection switching |
+| `mocks-manager.spec.ts` | 19 | Manager API, collection resolution |
+| `http-methods.spec.ts` | 22 | GET/POST/PUT/PATCH/DELETE, status codes |
+| `url-patterns.spec.ts` | 18 | URL paths, parameters |
+| `response-body.spec.ts` | 17 | Body structures, data types |
+| `edge-cases.spec.ts` | 17 | Error handling, edge cases |
+| `collection-inheritance.spec.ts` | 14 | Inheritance chains, overrides |
+| `websocket.spec.ts` | 11 | WebSocket transport |
+| `version.spec.ts` | 9 | API exports, enums |
+
+### By Original Category
+
+| Category | Total | ✅ Done | 🚧 Partial | ❌ TODO | ➖ N/A |
+|----------|-------|---------|------------|--------|--------|
+| Controller | 20 | 4 | 1 | 15 | 0 |
+| Mocks | 3 | 2 | 0 | 0 | 1 |
+| Loader | 2 | 1 | 0 | 0 | 1 |
+| Validation | 21 | 2 | 13 | 0 | 6 |
+| Lib: route-meta | 3 | 0 | 0 | 0 | 3 |
+| Lib: object-intersects | 3 | 0 | 0 | 3 | 0 |
+| Lib: url-matches | 2 | 0 | 0 | 2 | 0 |
+| Lib: get-single-expression | 5 | 0 | 0 | 5 | 0 |
+| Lib: compile-template | 11 | 0 | 0 | 11 | 0 |
+| **Total** | **70** | **9** | **14** | **36** | **11** |
+
+### Core Features Status
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Load collections from YAML | ✅ | Works with glob patterns |
+| Load routes from YAML | ✅ | Works with glob patterns |
+| Collection inheritance (`from`) | ✅ | Multi-level supported |
+| Route override in child collection | ✅ | Child wins over parent |
+| HTTP route handling | ✅ | GET, POST, etc. |
+| WebSocket route handling | ✅ | Transport type detection |
+| `useCollection` | ✅ | Switch active collection |
+| `getActiveRoutes` | ✅ | Return resolved routes |
+| `currentCollection` | ✅ | Getter for current ID |
+| `useRoutes` | ❌ | Dynamic route switching |
+| `useSocket` | ❌ | WebSocket route switching |
+| `resetRoutes` | ❌ | Reset to collection state |
+| `findRoute` | ❌ | Request matching |
+| URL path parameters | ❌ | `/users/:id` support |
+| Query matching | ❌ | `${query.page == '1'}` |
+| Header matching | 🚧 | Parsed, not tested for matching |
+| Payload matching | 🚧 | Parsed, not tested for matching |
+| JMESPath expressions | ❌ | For request matching |
+| Template interpolation | ❌ | `${request.id}` in responses |
+
+---
+
+## API Compatibility
+
+### MocksController (Rust) vs Controller (JS)
+
+```typescript
+// JS: example/mocker/controller.ts
+class Controller {
+  useCollection(id: string): Promise<Controller>
+  useRoutes(routes: string[]): Promise<Controller>
+  useSocket(routes: string[]): Promise<Controller>
+  resetRoutes(): Promise<Controller>
+  getWebSocket(route: string): Promise<WebSocket>
+  get state(): FlatRoute[]
+}
+
+// Rust: @mockito/binding
+class MocksController {
+  constructor(collectionsPath: string, routesPath: string, defaultCollection?: string)
+  useCollection(collectionId: string): void              // ✅
+  get currentCollection(): string | null                  // ✅
+  getActiveRoutes(): Array<ActiveRoute>                   // ✅
+  // Missing: useRoutes, useSocket, resetRoutes, getWebSocket
+}
+```
+
+### MocksManager (Rust) - New API
+
+```typescript
+// Rust: @mockito/binding (stateless alternative)
+class MocksManager {
+  constructor(collectionsPath: string, routesPath: string)
+  resolveCollection(collectionId: string): Array<ActiveRoute>  // ✅
+}
+```
+
+---
+
+## Migration Guide
+
+To use `@mockito/binding` as drop-in replacement:
+
+### Currently Supported
+
+```typescript
+// ✅ Creating controller with default collection
+const controller = new MocksController(collectionsPath, routesPath, 'my-collection');
+
+// ✅ Switching collections
+controller.useCollection('another-collection');
+
+// ✅ Getting active routes
+const routes = controller.getActiveRoutes();
+
+// ✅ Checking current collection
+console.log(controller.currentCollection);
+```
+
+### Not Yet Supported
+
+```typescript
+// ❌ Dynamic route switching
+await controller.useRoutes(['route:preset:variant']);
+
+// ❌ WebSocket route switching
+await controller.useSocket(['ws-route:preset:variant']);
+
+// ❌ Reset to collection state
+await controller.resetRoutes();
+
+// ❌ Request matching (findRoute equivalent)
+const matchedRoute = controller.findRoute(request);
+```

--- a/packages/mockito-e2e-tests/__fixtures__/collections.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/collections.yaml
@@ -1,0 +1,139 @@
+# Base collection - simple case
+- id: base
+  routes:
+    - users-api:success:default
+    - products-api:success:default
+
+# Collection with inheritance (from base)
+- id: extended
+  from: base
+  routes:
+    - users-api:error:not-found
+    - orders-api:success:default
+
+# Collection overriding parent route
+- id: override-parent
+  from: base
+  routes:
+    - users-api:success:empty-list
+
+# Deeply nested collection
+- id: deeply-nested
+  from: extended
+  routes:
+    - payments-api:success:default
+
+# Collection without inheritance
+- id: standalone
+  routes:
+    - users-api:success:default
+    - users-api:error:server-error
+
+# Collection with WebSocket routes
+- id: with-websocket
+  routes:
+    - ws-notifications:default:message
+
+# Empty collection (edge case)
+- id: minimal
+  routes:
+    - users-api:success:default
+
+# CRUD collection - all HTTP methods
+- id: crud-operations
+  routes:
+    - users-crud:get-by-id:found
+    - users-post:create:success
+    - users-put:update:success
+    - users-patch:partial-update:success
+    - users-delete:remove:success
+
+# Error responses collection
+- id: error-responses
+  routes:
+    - users-crud:get-by-id:not-found
+    - users-post:create:validation-error
+    - users-delete:remove:not-found
+    - auth-api:login:invalid-credentials
+
+# Health check collection
+- id: health
+  routes:
+    - health-check:default:healthy
+
+# Unhealthy state
+- id: health-unhealthy
+  from: health
+  routes:
+    - health-check:default:unhealthy
+
+# Search with query params
+- id: search
+  routes:
+    - search-api:with-query:results
+
+# Search empty
+- id: search-empty
+  routes:
+    - search-api:empty-query:no-results
+
+# Authentication flows
+- id: auth-success
+  routes:
+    - auth-api:login:success
+
+- id: auth-failed
+  routes:
+    - auth-api:login:invalid-credentials
+
+- id: auth-rate-limited
+  routes:
+    - auth-api:login:rate-limited
+
+# File upload
+- id: file-upload
+  routes:
+    - file-upload:upload:success
+
+- id: file-upload-error
+  routes:
+    - file-upload:upload:too-large
+
+# WebSocket chat
+- id: ws-chat
+  routes:
+    - ws-chat:default:connected
+
+- id: ws-chat-message
+  routes:
+    - ws-chat:default:message
+
+# Combined collection - multiple features
+- id: full-api
+  routes:
+    - users-api:success:default
+    - products-api:success:default
+    - orders-api:success:default
+    - health-check:default:healthy
+    - search-api:with-query:results
+    - auth-api:login:success
+
+# Multi-level inheritance test
+- id: level-1
+  routes:
+    - users-api:success:default
+
+- id: level-2
+  from: level-1
+  routes:
+    - products-api:success:default
+
+- id: level-3
+  from: level-2
+  routes:
+    - orders-api:success:default
+
+- id: level-4
+  from: level-3
+  routes:
+    - payments-api:success:default

--- a/packages/mockito-e2e-tests/__fixtures__/routes/auth.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/auth.yaml
@@ -1,0 +1,35 @@
+id: auth-api
+url: /api/auth/login
+transport: HTTP
+method: POST
+presets:
+  - id: login
+    headers:
+      Content-Type: application/json
+    payload:
+      username: admin
+      password: secret
+    variants:
+      - id: success
+        status: 200
+        headers:
+          Content-Type: application/json
+          Set-Cookie: session=abc123; HttpOnly
+        body:
+          token: jwt-token-here
+          expiresIn: 3600
+      - id: invalid-credentials
+        status: 401
+        headers:
+          Content-Type: application/json
+        body:
+          error: Invalid credentials
+          code: AUTH_FAILED
+      - id: rate-limited
+        status: 429
+        headers:
+          Content-Type: application/json
+          Retry-After: "60"
+        body:
+          error: Too many requests
+          retryAfter: 60

--- a/packages/mockito-e2e-tests/__fixtures__/routes/file-upload.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/file-upload.yaml
@@ -1,0 +1,25 @@
+id: file-upload
+url: /api/files
+transport: HTTP
+method: POST
+presets:
+  - id: upload
+    headers:
+      Content-Type: multipart/form-data
+    variants:
+      - id: success
+        status: 201
+        headers:
+          Content-Type: application/json
+        body:
+          fileId: file-123
+          filename: uploaded.pdf
+          size: 1024
+          url: /files/file-123
+      - id: too-large
+        status: 413
+        headers:
+          Content-Type: application/json
+        body:
+          error: File too large
+          maxSize: 10485760

--- a/packages/mockito-e2e-tests/__fixtures__/routes/health.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/health.yaml
@@ -1,0 +1,21 @@
+id: health-check
+url: /health
+transport: HTTP
+method: GET
+presets:
+  - id: default
+    variants:
+      - id: healthy
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          status: ok
+          timestamp: "2024-01-01T00:00:00Z"
+      - id: unhealthy
+        status: 503
+        headers:
+          Content-Type: application/json
+        body:
+          status: error
+          message: Service unavailable

--- a/packages/mockito-e2e-tests/__fixtures__/routes/orders.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/orders.yaml
@@ -1,0 +1,18 @@
+id: orders-api
+url: /api/orders
+transport: HTTP
+method: POST
+presets:
+  - id: success
+    headers:
+      Content-Type: application/json
+    payload:
+      productId: 1
+    variants:
+      - id: default
+        status: 201
+        headers:
+          Content-Type: application/json
+        body:
+          orderId: 12345
+          status: created

--- a/packages/mockito-e2e-tests/__fixtures__/routes/payments.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/payments.yaml
@@ -1,0 +1,16 @@
+id: payments-api
+url: /api/payments
+transport: HTTP
+method: POST
+presets:
+  - id: success
+    headers:
+      Authorization: Bearer ${headers.token}
+    variants:
+      - id: default
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          paymentId: pay_123
+          status: completed

--- a/packages/mockito-e2e-tests/__fixtures__/routes/products.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/products.yaml
@@ -1,0 +1,19 @@
+id: products-api
+url: /api/products
+transport: HTTP
+method: GET
+presets:
+  - id: success
+    variants:
+      - id: default
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          products:
+            - id: 1
+              name: Product A
+              price: 99.99
+            - id: 2
+              name: Product B
+              price: 149.99

--- a/packages/mockito-e2e-tests/__fixtures__/routes/query-params.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/query-params.yaml
@@ -1,0 +1,34 @@
+id: search-api
+url: /api/search
+transport: HTTP
+method: GET
+presets:
+  - id: with-query
+    query:
+      q: test
+      page: "1"
+      limit: "10"
+    variants:
+      - id: results
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          query: test
+          page: 1
+          limit: 10
+          results:
+            - id: 1
+              title: Test Result 1
+            - id: 2
+              title: Test Result 2
+          total: 100
+  - id: empty-query
+    variants:
+      - id: no-results
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          results: []
+          total: 0

--- a/packages/mockito-e2e-tests/__fixtures__/routes/users-crud.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/users-crud.yaml
@@ -1,0 +1,25 @@
+# Full CRUD operations for users
+id: users-crud
+url: /api/users/:id
+transport: HTTP
+method: GET
+presets:
+  - id: get-by-id
+    params:
+      id: "123"
+    variants:
+      - id: found
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          id: 123
+          name: John Doe
+          email: john@example.com
+      - id: not-found
+        status: 404
+        headers:
+          Content-Type: application/json
+        body:
+          error: User not found
+          code: USER_NOT_FOUND

--- a/packages/mockito-e2e-tests/__fixtures__/routes/users-delete.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/users-delete.yaml
@@ -1,0 +1,17 @@
+id: users-delete
+url: /api/users/:id
+transport: HTTP
+method: DELETE
+presets:
+  - id: remove
+    params:
+      id: "123"
+    variants:
+      - id: success
+        status: 204
+      - id: not-found
+        status: 404
+        headers:
+          Content-Type: application/json
+        body:
+          error: User not found

--- a/packages/mockito-e2e-tests/__fixtures__/routes/users-patch.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/users-patch.yaml
@@ -1,0 +1,16 @@
+id: users-patch
+url: /api/users/:id
+transport: HTTP
+method: PATCH
+presets:
+  - id: partial-update
+    params:
+      id: "123"
+    variants:
+      - id: success
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          id: 123
+          patched: true

--- a/packages/mockito-e2e-tests/__fixtures__/routes/users-post.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/users-post.yaml
@@ -1,0 +1,28 @@
+id: users-post
+url: /api/users
+transport: HTTP
+method: POST
+presets:
+  - id: create
+    headers:
+      Content-Type: application/json
+    payload:
+      name: New User
+    variants:
+      - id: success
+        status: 201
+        headers:
+          Content-Type: application/json
+          Location: /api/users/999
+        body:
+          id: 999
+          name: New User
+          created: true
+      - id: validation-error
+        status: 400
+        headers:
+          Content-Type: application/json
+        body:
+          error: Validation failed
+          fields:
+            - name: required

--- a/packages/mockito-e2e-tests/__fixtures__/routes/users-put.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/users-put.yaml
@@ -1,0 +1,19 @@
+id: users-put
+url: /api/users/:id
+transport: HTTP
+method: PUT
+presets:
+  - id: update
+    params:
+      id: "123"
+    headers:
+      Content-Type: application/json
+    variants:
+      - id: success
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          id: 123
+          name: Updated User
+          updated: true

--- a/packages/mockito-e2e-tests/__fixtures__/routes/users.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/users.yaml
@@ -1,0 +1,43 @@
+id: users-api
+url: /api/users
+transport: HTTP
+method: GET
+presets:
+  - id: success
+    variants:
+      - id: default
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          data:
+            - id: 1
+              name: John Doe
+              email: john@example.com
+            - id: 2
+              name: Jane Doe
+              email: jane@example.com
+          total: 2
+      - id: empty-list
+        status: 200
+        headers:
+          Content-Type: application/json
+        body:
+          data: []
+          total: 0
+  - id: error
+    variants:
+      - id: not-found
+        status: 404
+        headers:
+          Content-Type: application/json
+        body:
+          error: Users not found
+          code: NOT_FOUND
+      - id: server-error
+        status: 500
+        headers:
+          Content-Type: application/json
+        body:
+          error: Internal server error
+          code: SERVER_ERROR

--- a/packages/mockito-e2e-tests/__fixtures__/routes/websocket.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/websocket.yaml
@@ -1,0 +1,12 @@
+id: ws-notifications
+url: /ws/notifications
+transport: WEBSOCKET
+presets:
+  - id: default
+    variants:
+      - id: message
+        body:
+          type: notification
+          payload:
+            title: New message
+            content: Hello, world!

--- a/packages/mockito-e2e-tests/__fixtures__/routes/ws-chat.yaml
+++ b/packages/mockito-e2e-tests/__fixtures__/routes/ws-chat.yaml
@@ -1,0 +1,17 @@
+id: ws-chat
+url: /ws/chat
+transport: WEBSOCKET
+presets:
+  - id: default
+    variants:
+      - id: connected
+        body:
+          type: connected
+          userId: user-123
+          room: general
+      - id: message
+        body:
+          type: message
+          from: user-456
+          text: Hello, World!
+          timestamp: "2024-01-01T12:00:00Z"

--- a/packages/mockito-e2e-tests/__tests__/collection-inheritance.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/collection-inheritance.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * Collection Inheritance Tests
+ *
+ * Tests for collection inheritance via 'from' field.
+ *
+ * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection with nesting"
+ * @see example/mocker/controller.ts - fillNestedRoutes method
+ */
+import path from 'node:path';
+import {describe, expect, it, beforeAll} from '@rstest/core';
+import {MocksManager, MocksController} from '@mockito/binding';
+
+const FIXTURES_PATH = path.join(import.meta.dirname, '..', '__fixtures__');
+const COLLECTIONS_PATH = path.join(FIXTURES_PATH, 'collections.yaml');
+const ROUTES_PATH = path.join(FIXTURES_PATH, 'routes', '*.yaml');
+
+describe('Collection Inheritance', () => {
+    let manager: MocksManager;
+
+    beforeAll(() => {
+        manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+    });
+
+    describe('single level inheritance', () => {
+        /**
+         * Tests basic inheritance with 'from' field.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection with nesting"
+         */
+        it('should inherit routes from parent collection', () => {
+            const parentRoutes = manager.resolveCollection('base');
+            const childRoutes = manager.resolveCollection('extended');
+
+            // Parent has 2 routes
+            expect(parentRoutes).toHaveLength(2);
+
+            // Child inherits from parent and adds more
+            expect(childRoutes.length).toBeGreaterThan(parentRoutes.length);
+
+            // Parent routes should be present in child
+            const parentIds = parentRoutes.map(r => r.route.id);
+            const childIds = childRoutes.map(r => r.route.id);
+
+            parentIds.forEach(id => {
+                expect(childIds).toContain(id);
+            });
+        });
+
+        /**
+         * Tests that child routes override parent routes.
+         * @see example/mocker/controller.ts - fillNestedRoutes: child wins
+         */
+        it('should override parent route when child defines same route id', () => {
+            const parentRoutes = manager.resolveCollection('base');
+            const childRoutes = manager.resolveCollection('override-parent');
+
+            const parentUsersRoute = parentRoutes.find(r => r.route.id === 'users-api');
+            const childUsersRoute = childRoutes.find(r => r.route.id === 'users-api');
+
+            // Parent has default variant
+            expect(parentUsersRoute?.variant.id).toBe('default');
+
+            // Child overrides with empty-list variant
+            expect(childUsersRoute?.variant.id).toBe('empty-list');
+        });
+    });
+
+    describe('multi-level inheritance', () => {
+        /**
+         * Tests two-level inheritance chain.
+         * @see example/mocker/controller.ts - recursive fillNestedRoutes
+         */
+        it('should support two-level inheritance', () => {
+            const level1Routes = manager.resolveCollection('level-1');
+            const level2Routes = manager.resolveCollection('level-2');
+
+            expect(level1Routes).toHaveLength(1);
+            expect(level2Routes).toHaveLength(2);
+
+            const level2Ids = level2Routes.map(r => r.route.id);
+            expect(level2Ids).toContain('users-api');
+            expect(level2Ids).toContain('products-api');
+        });
+
+        /**
+         * Tests three-level inheritance chain.
+         * @see example/mocker/controller.ts - recursive fillNestedRoutes
+         */
+        it('should support three-level inheritance', () => {
+            const level3Routes = manager.resolveCollection('level-3');
+
+            expect(level3Routes).toHaveLength(3);
+
+            const ids = level3Routes.map(r => r.route.id);
+            expect(ids).toContain('users-api');
+            expect(ids).toContain('products-api');
+            expect(ids).toContain('orders-api');
+        });
+
+        /**
+         * Tests four-level inheritance chain.
+         * @see example/mocker/controller.ts - recursive fillNestedRoutes
+         */
+        it('should support four-level inheritance', () => {
+            const level4Routes = manager.resolveCollection('level-4');
+
+            expect(level4Routes).toHaveLength(4);
+
+            const ids = level4Routes.map(r => r.route.id);
+            expect(ids).toContain('users-api');
+            expect(ids).toContain('products-api');
+            expect(ids).toContain('orders-api');
+            expect(ids).toContain('payments-api');
+        });
+
+        /**
+         * Tests deeply nested collection (base → extended → deeply-nested).
+         * @see example/mocker/controller.ts - recursive fillNestedRoutes
+         */
+        it('should resolve deeply-nested inheritance chain', () => {
+            const routes = manager.resolveCollection('deeply-nested');
+
+            // Should have all routes from the chain
+            const ids = routes.map(r => r.route.id);
+            expect(ids).toContain('users-api');     // from base
+            expect(ids).toContain('products-api');  // from base
+            expect(ids).toContain('orders-api');    // from extended
+            expect(ids).toContain('payments-api');  // from deeply-nested
+        });
+    });
+
+    describe('override behavior in inheritance chain', () => {
+        /**
+         * Tests override at second level.
+         * @see example/mocker/controller.ts - fillNestedRoutes identifier check
+         */
+        it('should use child preset when overriding', () => {
+            const routes = manager.resolveCollection('extended');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            // extended defines users-api:error:not-found which overrides base's users-api:success:default
+            expect(usersRoute?.preset.id).toBe('error');
+            expect(usersRoute?.variant.id).toBe('not-found');
+        });
+
+        /**
+         * Tests that non-overridden routes keep parent values.
+         * @see example/mocker/controller.ts - fillNestedRoutes preserves parent routes
+         */
+        it('should preserve parent routes that are not overridden', () => {
+            const routes = manager.resolveCollection('extended');
+            const productsRoute = routes.find(r => r.route.id === 'products-api');
+
+            // products-api is not overridden, should have parent's preset
+            expect(productsRoute?.preset.id).toBe('success');
+            expect(productsRoute?.variant.id).toBe('default');
+        });
+    });
+
+    describe('collections without inheritance', () => {
+        /**
+         * Tests collection without 'from' field.
+         * @see example/mocker/controller.ts - fillNestedRoutes returns early if !collection.from
+         */
+        it('should work without inheritance', () => {
+            const routes = manager.resolveCollection('standalone');
+
+            // standalone has its own routes only
+            expect(routes.length).toBeGreaterThanOrEqual(1);
+        });
+
+        /**
+         * Tests minimal collection.
+         * @see example/mocker/controller.ts - basic collection handling
+         */
+        it('should resolve minimal collection', () => {
+            const routes = manager.resolveCollection('minimal');
+
+            expect(routes).toHaveLength(1);
+            expect(routes[0]?.route.id).toBe('users-api');
+        });
+    });
+
+    describe('MocksController inheritance', () => {
+        /**
+         * Tests inheritance via MocksController.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection with nesting"
+         */
+        it('should resolve inheritance when using controller', () => {
+            const controller = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+
+            controller.useCollection('deeply-nested');
+            const routes = controller.getActiveRoutes();
+
+            const ids = routes.map(r => r.route.id);
+            expect(ids).toContain('users-api');
+            expect(ids).toContain('products-api');
+            expect(ids).toContain('orders-api');
+            expect(ids).toContain('payments-api');
+        });
+
+        /**
+         * Tests switching between collections with different inheritance.
+         * @see example/mocker/controller.ts - useCollection resets state
+         */
+        it('should correctly switch between collections with different inheritance depth', () => {
+            const controller = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+
+            controller.useCollection('base');
+            expect(controller.getActiveRoutes()).toHaveLength(2);
+
+            controller.useCollection('level-4');
+            expect(controller.getActiveRoutes()).toHaveLength(4);
+
+            controller.useCollection('minimal');
+            expect(controller.getActiveRoutes()).toHaveLength(1);
+        });
+    });
+
+    describe('inheritance with overrides at each level', () => {
+        /**
+         * Tests override propagation through inheritance chain.
+         * @see example/mocker/controller.ts - fillNestedRoutes order matters
+         */
+        it('should propagate overrides correctly through chain', () => {
+            // extended overrides users-api from base
+            const extendedRoutes = manager.resolveCollection('extended');
+            const extendedUsers = extendedRoutes.find(r => r.route.id === 'users-api');
+            expect(extendedUsers?.preset.id).toBe('error');
+
+            // deeply-nested inherits from extended, keeps the override
+            const deepRoutes = manager.resolveCollection('deeply-nested');
+            const deepUsers = deepRoutes.find(r => r.route.id === 'users-api');
+            expect(deepUsers?.preset.id).toBe('error');
+        });
+    });
+
+    describe('inheritance with full-api collection', () => {
+        /**
+         * Tests collection with many routes but no inheritance.
+         * @see example/mocker/controller.ts - routes array handling
+         */
+        it('should handle collection with many routes', () => {
+            const routes = manager.resolveCollection('full-api');
+
+            expect(routes.length).toBe(6);
+
+            const ids = routes.map(r => r.route.id);
+            expect(ids).toContain('users-api');
+            expect(ids).toContain('products-api');
+            expect(ids).toContain('orders-api');
+            expect(ids).toContain('health-check');
+            expect(ids).toContain('search-api');
+            expect(ids).toContain('auth-api');
+        });
+    });
+});

--- a/packages/mockito-e2e-tests/__tests__/edge-cases.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/edge-cases.spec.ts
@@ -1,0 +1,264 @@
+/**
+ * Edge Cases and Error Handling Tests
+ *
+ * These tests verify error handling and boundary conditions.
+ * Some behaviors may differ between JS and Rust implementations.
+ *
+ * @see example/mocker/__specs__/loader.spec.ts for file loading tests
+ * @see example/mocker/__specs__/validation.spec.ts for validation edge cases
+ */
+import path from 'node:path';
+import {describe, expect, it} from '@rstest/core';
+import {MocksManager, MocksController} from '@mockito/binding';
+
+const FIXTURES_PATH = path.join(import.meta.dirname, '..', '__fixtures__');
+const COLLECTIONS_PATH = path.join(FIXTURES_PATH, 'collections.yaml');
+const ROUTES_PATH = path.join(FIXTURES_PATH, 'routes', '*.yaml');
+
+describe('Edge Cases', () => {
+    describe('file loading', () => {
+        /**
+         * Tests error when collections file doesn't exist.
+         * @see example/mocker/__specs__/mocks.spec.ts - "should throw if no collection found"
+         * @see example/mocker/__specs__/loader.spec.ts - file loading tests
+         */
+        it('should throw error for non-existent collections file', () => {
+            expect(
+                () => new MocksManager('/non/existent/collections.yaml', ROUTES_PATH)
+            ).toThrow();
+        });
+
+        /**
+         * Tests behavior for non-existent routes glob pattern.
+         * Note: Rust implementation may not throw for empty glob results.
+         * @see example/mocker/__specs__/loader.spec.ts - "should load file based on data from ctor"
+         */
+        it('should not throw error for non-existent routes directory (empty result)', () => {
+            // Rust implementation returns empty routes array for non-existent glob pattern
+            // This is by design - glob patterns can match zero files
+            const manager = new MocksManager(COLLECTIONS_PATH, '/non/existent/routes/*.yaml');
+            
+            // Resolving collection should throw because routes don't exist
+            expect(() => manager.resolveCollection('base')).toThrow();
+        });
+
+        /**
+         * Tests error for invalid collections path in MocksController.
+         * @see example/mocker/__specs__/mocks.spec.ts - "should throw if no collection found"
+         */
+        it('should throw error for invalid collections path', () => {
+            expect(
+                () => new MocksController('/invalid/path.yaml', ROUTES_PATH)
+            ).toThrow();
+        });
+    });
+
+    describe('collection resolution errors', () => {
+        /**
+         * Tests MocksManager error for non-existent collection.
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if no collection found"
+         */
+        it('MocksManager should throw for non-existent collection', () => {
+            const manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+
+            expect(() => manager.resolveCollection('does-not-exist')).toThrow();
+        });
+
+        /**
+         * Tests MocksController error for non-existent collection.
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if no collection found"
+         */
+        it('MocksController should throw for non-existent collection', () => {
+            const controller = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+
+            expect(() => controller.useCollection('does-not-exist')).toThrow();
+        });
+    });
+
+    describe('multiple instances', () => {
+        /**
+         * Tests that multiple MocksManager instances can coexist.
+         * @see example/mocker/mocks.ts - Mocks class is stateless after load()
+         */
+        it('should allow creating multiple MocksManager instances', () => {
+            const manager1 = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+            const manager2 = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+
+            const routes1 = manager1.resolveCollection('base');
+            const routes2 = manager2.resolveCollection('base');
+
+            expect(routes1).toHaveLength(routes2.length);
+        });
+
+        /**
+         * Tests that multiple MocksController instances can coexist.
+         * @see example/mocker/controller.ts - Controller maintains its own state
+         */
+        it('should allow creating multiple MocksController instances', () => {
+            const controller1 = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+            const controller2 = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+
+            controller1.useCollection('base');
+            controller2.useCollection('extended');
+
+            expect(controller1.currentCollection).toBe('base');
+            expect(controller2.currentCollection).toBe('extended');
+        });
+
+        /**
+         * Tests that controllers are independent of each other.
+         * @see example/mocker/controller.ts - Controller has own selectedCollection state
+         */
+        it('controllers should be independent', () => {
+            const controller1 = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+            const controller2 = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+
+            controller1.useCollection('base');
+            controller2.useCollection('extended');
+
+            // Changing controller2 should not affect controller1
+            controller2.useCollection('standalone');
+
+            expect(controller1.currentCollection).toBe('base');
+            expect(controller2.currentCollection).toBe('standalone');
+        });
+    });
+
+    describe('route data integrity', () => {
+        /**
+         * Tests that response body structure is preserved through YAML parsing.
+         * @see example/mocker/__specs__/loader.spec.ts - YAML content preservation test
+         */
+        it('should preserve response body structure', () => {
+            const manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+            const routes = manager.resolveCollection('base');
+
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+            const body = usersRoute?.variant.body as {
+                data: Array<{id: number; name: string; email: string}>;
+                total: number;
+            };
+
+            expect(body).toBeDefined();
+            expect(body.data).toBeInstanceOf(Array);
+            expect(body.data[0]).toHaveProperty('id');
+            expect(body.data[0]).toHaveProperty('name');
+            expect(body.data[0]).toHaveProperty('email');
+            expect(typeof body.total).toBe('number');
+        });
+
+        /**
+         * Tests that header values are preserved.
+         * @see example/mocker/validation.ts - headers field in variant
+         */
+        it('should preserve header values', () => {
+            const manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+            const routes = manager.resolveCollection('base');
+
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+            const headers = usersRoute?.variant.headers;
+
+            expect(headers).toBeDefined();
+            expect(headers?.['Content-Type']).toBe('application/json');
+        });
+
+        /**
+         * Tests that status codes are preserved.
+         * @see example/mocker/validation.ts - status field in variant (VARIANT_SCHEMA)
+         */
+        it('should preserve status codes', () => {
+            const manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+
+            // Success response
+            const baseRoutes = manager.resolveCollection('base');
+            const successRoute = baseRoutes.find(r => r.route.id === 'users-api');
+            expect(successRoute?.variant.status).toBe(200);
+
+            // Error response
+            const extendedRoutes = manager.resolveCollection('extended');
+            const errorRoute = extendedRoutes.find(r => r.route.id === 'users-api');
+            expect(errorRoute?.variant.status).toBe(404);
+        });
+    });
+
+    describe('preset matching conditions', () => {
+        /**
+         * Tests expression-based header conditions parsing.
+         * @see example/mocker/validation.ts - STRING_OR_NON_EMPTY_STRING_RECORD for headers
+         * @see example/mocker/consts.ts - EXPRESSION_REGEX for ${} syntax
+         */
+        it('should parse expression-based header conditions', () => {
+            const manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+            const routes = manager.resolveCollection('deeply-nested');
+
+            const paymentsRoute = routes.find(r => r.route.id === 'payments-api');
+            expect(paymentsRoute?.preset.headers).toBeDefined();
+        });
+
+        /**
+         * Tests object-based payload conditions parsing.
+         * @see example/mocker/validation.ts - STRING_OR_NON_EMPTY_OBJECT for payload
+         */
+        it('should parse object-based payload conditions', () => {
+            const manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+            const routes = manager.resolveCollection('extended');
+
+            const ordersRoute = routes.find(r => r.route.id === 'orders-api');
+            expect(ordersRoute?.preset.payload).toBeDefined();
+        });
+    });
+
+    describe('URL patterns', () => {
+        /**
+         * Tests API URL path preservation.
+         * @see example/mocker/validation.ts - url field is required string
+         */
+        it('should correctly parse API URL paths', () => {
+            const manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+            const routes = manager.resolveCollection('base');
+
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+            expect(usersRoute?.route.url).toBe('/api/users');
+
+            const productsRoute = routes.find(r => r.route.id === 'products-api');
+            expect(productsRoute?.route.url).toBe('/api/products');
+        });
+
+        /**
+         * Tests WebSocket URL path preservation.
+         * @see example/mocker/validation.ts - url field for WS routes
+         */
+        it('should correctly parse WebSocket URL paths', () => {
+            const manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+            const routes = manager.resolveCollection('with-websocket');
+
+            const wsRoute = routes.find(r => r.route.id === 'ws-notifications');
+            expect(wsRoute?.route.url).toBe('/ws/notifications');
+        });
+    });
+
+    describe('default collection', () => {
+        /**
+         * Tests that default collection is applied on construction.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection"
+         */
+        it('should apply default collection on construction', () => {
+            const controller = new MocksController(COLLECTIONS_PATH, ROUTES_PATH, 'base');
+
+            expect(controller.currentCollection).toBe('base');
+            expect(controller.getActiveRoutes()).toHaveLength(2);
+        });
+
+        /**
+         * Tests switching from default collection to another.
+         * @see example/mocker/controller.ts - useCollection can be called after constructor
+         */
+        it('should allow switching from default collection', () => {
+            const controller = new MocksController(COLLECTIONS_PATH, ROUTES_PATH, 'base');
+
+            controller.useCollection('extended');
+
+            expect(controller.currentCollection).toBe('extended');
+        });
+    });
+});

--- a/packages/mockito-e2e-tests/__tests__/http-methods.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/http-methods.spec.ts
@@ -1,0 +1,287 @@
+/**
+ * HTTP Methods Tests
+ *
+ * Tests for all HTTP methods support (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS).
+ *
+ * @see example/mocker/consts.ts - HTTP_METHODS constant
+ * @see example/mocker/validation.ts - method field validation
+ */
+import path from 'node:path';
+import {describe, expect, it, beforeAll} from '@rstest/core';
+import {MocksManager, HttpMethod, Transport} from '@mockito/binding';
+
+const FIXTURES_PATH = path.join(import.meta.dirname, '..', '__fixtures__');
+const COLLECTIONS_PATH = path.join(FIXTURES_PATH, 'collections.yaml');
+const ROUTES_PATH = path.join(FIXTURES_PATH, 'routes', '*.yaml');
+
+describe('HTTP Methods', () => {
+    let manager: MocksManager;
+
+    beforeAll(() => {
+        manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+    });
+
+    describe('CRUD operations', () => {
+        /**
+         * Tests GET method for reading resources.
+         * @see example/mocker/consts.ts - HTTP_METHODS includes 'GET'
+         */
+        it('should support GET method', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const getRoute = routes.find(r => r.route.id === 'users-crud');
+
+            expect(getRoute).toBeDefined();
+            expect(getRoute?.route.method).toBe(HttpMethod.Get);
+            expect(getRoute?.route.url).toBe('/api/users/:id');
+        });
+
+        /**
+         * Tests POST method for creating resources.
+         * @see example/mocker/consts.ts - HTTP_METHODS includes 'POST'
+         */
+        it('should support POST method', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const postRoute = routes.find(r => r.route.id === 'users-post');
+
+            expect(postRoute).toBeDefined();
+            expect(postRoute?.route.method).toBe(HttpMethod.Post);
+            expect(postRoute?.variant.status).toBe(201);
+        });
+
+        /**
+         * Tests PUT method for replacing resources.
+         * @see example/mocker/consts.ts - HTTP_METHODS includes 'PUT'
+         */
+        it('should support PUT method', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const putRoute = routes.find(r => r.route.id === 'users-put');
+
+            expect(putRoute).toBeDefined();
+            expect(putRoute?.route.method).toBe(HttpMethod.Put);
+        });
+
+        /**
+         * Tests PATCH method for partial updates.
+         * @see example/mocker/consts.ts - HTTP_METHODS includes 'PATCH'
+         */
+        it('should support PATCH method', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const patchRoute = routes.find(r => r.route.id === 'users-patch');
+
+            expect(patchRoute).toBeDefined();
+            expect(patchRoute?.route.method).toBe(HttpMethod.Patch);
+        });
+
+        /**
+         * Tests DELETE method for removing resources.
+         * @see example/mocker/consts.ts - HTTP_METHODS includes 'DELETE'
+         */
+        it('should support DELETE method', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const deleteRoute = routes.find(r => r.route.id === 'users-delete');
+
+            expect(deleteRoute).toBeDefined();
+            expect(deleteRoute?.route.method).toBe(HttpMethod.Delete);
+            expect(deleteRoute?.variant.status).toBe(204);
+        });
+    });
+
+    describe('response status codes', () => {
+        /**
+         * Tests 200 OK status.
+         * @see example/mocker/validation.ts - Variant status field
+         */
+        it('should return 200 for successful GET', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-crud');
+
+            expect(route?.variant.status).toBe(200);
+        });
+
+        /**
+         * Tests 201 Created status.
+         * @see example/mocker/validation.ts - Variant status field
+         */
+        it('should return 201 for successful POST', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-post');
+
+            expect(route?.variant.status).toBe(201);
+        });
+
+        /**
+         * Tests 204 No Content status.
+         * @see example/mocker/validation.ts - Variant status field
+         */
+        it('should return 204 for successful DELETE', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-delete');
+
+            expect(route?.variant.status).toBe(204);
+        });
+
+        /**
+         * Tests 400 Bad Request status.
+         * @see example/mocker/validation.ts - Variant status field
+         */
+        it('should return 400 for validation error', () => {
+            const routes = manager.resolveCollection('error-responses');
+            const route = routes.find(r => r.route.id === 'users-post');
+
+            expect(route?.variant.status).toBe(400);
+        });
+
+        /**
+         * Tests 401 Unauthorized status.
+         * @see example/mocker/validation.ts - Variant status field
+         */
+        it('should return 401 for authentication error', () => {
+            const routes = manager.resolveCollection('auth-failed');
+            const route = routes.find(r => r.route.id === 'auth-api');
+
+            expect(route?.variant.status).toBe(401);
+        });
+
+        /**
+         * Tests 404 Not Found status.
+         * @see example/mocker/validation.ts - Variant status field
+         */
+        it('should return 404 for not found', () => {
+            const routes = manager.resolveCollection('error-responses');
+            const route = routes.find(r => r.route.id === 'users-crud');
+
+            expect(route?.variant.status).toBe(404);
+        });
+
+        /**
+         * Tests 429 Too Many Requests status.
+         * @see example/mocker/validation.ts - Variant status field
+         */
+        it('should return 429 for rate limiting', () => {
+            const routes = manager.resolveCollection('auth-rate-limited');
+            const route = routes.find(r => r.route.id === 'auth-api');
+
+            expect(route?.variant.status).toBe(429);
+        });
+
+        /**
+         * Tests 503 Service Unavailable status.
+         * @see example/mocker/validation.ts - Variant status field
+         */
+        it('should return 503 for service unavailable', () => {
+            const routes = manager.resolveCollection('health-unhealthy');
+            const route = routes.find(r => r.route.id === 'health-check');
+
+            expect(route?.variant.status).toBe(503);
+        });
+    });
+
+    describe('response headers', () => {
+        /**
+         * Tests Content-Type header preservation.
+         * @see example/mocker/validation.ts - headers in Variant
+         */
+        it('should include Content-Type header', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-crud');
+
+            expect(route?.variant.headers?.['Content-Type']).toBe('application/json');
+        });
+
+        /**
+         * Tests Location header for created resources.
+         * @see example/mocker/validation.ts - headers in Variant
+         */
+        it('should include Location header for 201 response', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-post');
+
+            expect(route?.variant.headers?.['Location']).toBe('/api/users/999');
+        });
+
+        /**
+         * Tests Set-Cookie header.
+         * @see example/mocker/validation.ts - headers in Variant
+         */
+        it('should include Set-Cookie header for auth', () => {
+            const routes = manager.resolveCollection('auth-success');
+            const route = routes.find(r => r.route.id === 'auth-api');
+
+            expect(route?.variant.headers?.['Set-Cookie']).toBe('session=abc123; HttpOnly');
+        });
+
+        /**
+         * Tests Retry-After header.
+         * @see example/mocker/validation.ts - headers in Variant
+         */
+        it('should include Retry-After header for rate limiting', () => {
+            const routes = manager.resolveCollection('auth-rate-limited');
+            const route = routes.find(r => r.route.id === 'auth-api');
+
+            expect(route?.variant.headers?.['Retry-After']).toBe('60');
+        });
+    });
+
+    describe('preset conditions', () => {
+        /**
+         * Tests params in preset.
+         * @see example/mocker/validation.ts - params in Preset
+         */
+        it('should parse URL params in preset', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-crud');
+
+            expect(route?.preset.params).toBeDefined();
+            expect(route?.preset.params?.id).toBe('123');
+        });
+
+        /**
+         * Tests headers condition in preset.
+         * @see example/mocker/validation.ts - headers in Preset
+         */
+        it('should parse headers condition in preset', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-post');
+
+            expect(route?.preset.headers).toBeDefined();
+        });
+
+        /**
+         * Tests payload condition in preset.
+         * @see example/mocker/validation.ts - payload in Preset
+         */
+        it('should parse payload condition in preset', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-post');
+
+            expect(route?.preset.payload).toBeDefined();
+        });
+
+        /**
+         * Tests query condition in preset.
+         * @see example/mocker/validation.ts - query in Preset
+         */
+        it('should parse query condition in preset', () => {
+            const routes = manager.resolveCollection('search');
+            const route = routes.find(r => r.route.id === 'search-api');
+
+            expect(route?.preset.query).toBeDefined();
+            expect(route?.preset.query?.q).toBe('test');
+            expect(route?.preset.query?.page).toBe('1');
+        });
+    });
+
+    describe('all routes have HTTP transport', () => {
+        /**
+         * Tests that all CRUD routes have HTTP transport.
+         * @see example/mocker/consts.ts - Transport types
+         */
+        it('should have HTTP transport for all CRUD routes', () => {
+            const routes = manager.resolveCollection('crud-operations');
+
+            routes.forEach(route => {
+                expect(route.route.transport).toBe(Transport.Http);
+            });
+        });
+    });
+});

--- a/packages/mockito-e2e-tests/__tests__/mocks-controller.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/mocks-controller.spec.ts
@@ -1,0 +1,391 @@
+/**
+ * E2E Tests for MocksController (Rust implementation)
+ *
+ * These tests document expected behavior based on the original JS implementation.
+ * Some tests may fail if features are not yet implemented in Rust - this is expected
+ * and helps track implementation progress.
+ *
+ * MocksController manages stateful collection switching and provides active routes.
+ *
+ * @see example/mocker/__specs__/controller.spec.ts for original tests
+ * @see example/mocker/controller.ts for original implementation
+ */
+import path from 'node:path';
+import {describe, expect, it, beforeEach} from '@rstest/core';
+import {MocksController, Transport, HttpMethod} from '@mockito/binding';
+
+const FIXTURES_PATH = path.join(import.meta.dirname, '..', '__fixtures__');
+const COLLECTIONS_PATH = path.join(FIXTURES_PATH, 'collections.yaml');
+const ROUTES_PATH = path.join(FIXTURES_PATH, 'routes', '*.yaml');
+
+describe('MocksController', () => {
+    let controller: MocksController;
+
+    beforeEach(() => {
+        controller = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+    });
+
+    describe('constructor', () => {
+        /**
+         * Tests controller initialization without default collection.
+         * In JS version, Controller is created with pre-loaded collections/routes.
+         * @see example/mocker/__specs__/controller.spec.ts - createController()
+         */
+        it('should create controller without default collection', () => {
+            const ctrl = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+            expect(ctrl.currentCollection).toBeNull();
+        });
+
+        /**
+         * Tests controller initialization with default collection applied.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection"
+         */
+        it('should create controller with default collection', () => {
+            const ctrl = new MocksController(COLLECTIONS_PATH, ROUTES_PATH, 'base');
+            expect(ctrl.currentCollection).toBe('base');
+        });
+
+        /**
+         * Tests error when non-existent default collection is provided.
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if no collection found"
+         */
+        it('should throw error for non-existent default collection', () => {
+            expect(
+                () => new MocksController(COLLECTIONS_PATH, ROUTES_PATH, 'non-existent')
+            ).toThrow();
+        });
+    });
+
+    describe('useCollection', () => {
+        /**
+         * Tests switching to a specific collection.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection"
+         */
+        it('should switch to specified collection', () => {
+            controller.useCollection('base');
+
+            expect(controller.currentCollection).toBe('base');
+        });
+
+        /**
+         * Tests switching between different collections.
+         * @see example/mocker/__specs__/controller.spec.ts - multiple useCollection calls
+         */
+        it('should switch between collections', () => {
+            controller.useCollection('base');
+            expect(controller.currentCollection).toBe('base');
+
+            controller.useCollection('extended');
+            expect(controller.currentCollection).toBe('extended');
+        });
+
+        /**
+         * Tests error handling for non-existent collection.
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if no collection found"
+         */
+        it('should throw error for non-existent collection', () => {
+            expect(() => controller.useCollection('non-existent')).toThrow();
+        });
+    });
+
+    describe('getActiveRoutes', () => {
+        /**
+         * Tests that no routes returned when no collection is selected.
+         * @see example/mocker/__specs__/controller.spec.ts - "should restore mock to nothing if no collection selected"
+         */
+        it('should return empty array when no collection selected', () => {
+            const routes = controller.getActiveRoutes();
+            expect(routes).toHaveLength(0);
+        });
+
+        /**
+         * Tests that active routes are returned after selecting collection.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection"
+         */
+        it('should return active routes after selecting collection', () => {
+            controller.useCollection('base');
+
+            const routes = controller.getActiveRoutes();
+            expect(routes).toHaveLength(2);
+        });
+
+        /**
+         * Tests collection inheritance (from field) resolution.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection with nesting"
+         */
+        it('should return routes with inheritance resolved', () => {
+            controller.useCollection('extended');
+
+            const routes = controller.getActiveRoutes();
+            expect(routes.length).toBeGreaterThanOrEqual(3);
+
+            const routeIds = routes.map(r => r.route.id);
+            expect(routeIds).toContain('users-api');
+            expect(routeIds).toContain('products-api');
+            expect(routeIds).toContain('orders-api');
+        });
+
+        /**
+         * Tests WebSocket route handling.
+         * @see example/mocker/__specs__/controller.spec.ts - "should pass parser url for websocket route"
+         */
+        it('should return WebSocket routes', () => {
+            controller.useCollection('with-websocket');
+
+            const routes = controller.getActiveRoutes();
+            expect(routes).toHaveLength(1);
+
+            expect(routes[0]?.route.transport).toBe(Transport.WebSocket);
+        });
+    });
+
+    describe('currentCollection', () => {
+        /**
+         * Tests initial state before any collection is selected.
+         * @see example/mocker/controller.ts - selectedCollection initial value
+         */
+        it('should be null initially', () => {
+            expect(controller.currentCollection).toBeNull();
+        });
+
+        /**
+         * Tests currentCollection getter after useCollection.
+         * @see example/mocker/controller.ts - useCollection method
+         */
+        it('should return current collection id after useCollection', () => {
+            controller.useCollection('standalone');
+
+            expect(controller.currentCollection).toBe('standalone');
+        });
+
+        /**
+         * Tests that currentCollection updates when switching.
+         * @see example/mocker/controller.ts - useCollection updates selectedCollection
+         */
+        it('should update when switching collections', () => {
+            controller.useCollection('base');
+            controller.useCollection('minimal');
+
+            expect(controller.currentCollection).toBe('minimal');
+        });
+    });
+
+    describe('route structure validation', () => {
+        /**
+         * Tests Route structure from Rust binding matches expected shape.
+         * @see example/mocker/validation.ts - Route type definition
+         */
+        it('should have route with all required fields', () => {
+            controller.useCollection('base');
+            const routes = controller.getActiveRoutes();
+            const route = routes[0];
+
+            expect(route).toBeDefined();
+            expect(route?.route.id).toBeDefined();
+            expect(route?.route.url).toBeDefined();
+            expect(route?.route.transport).toBeDefined();
+            expect(route?.route.presets).toBeDefined();
+        });
+
+        /**
+         * Tests Preset structure from Rust binding.
+         * @see example/mocker/validation.ts - Preset type (PRESET_SCHEMA)
+         */
+        it('should have preset with variants', () => {
+            controller.useCollection('base');
+            const routes = controller.getActiveRoutes();
+            const route = routes[0];
+
+            expect(route?.preset.id).toBeDefined();
+            expect(route?.preset.variants).toBeDefined();
+            expect(Array.isArray(route?.preset.variants)).toBe(true);
+        });
+
+        /**
+         * Tests Variant structure from Rust binding.
+         * @see example/mocker/validation.ts - Variant type (VARIANT_SCHEMA)
+         */
+        it('should have variant with response data', () => {
+            controller.useCollection('base');
+            const routes = controller.getActiveRoutes();
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            expect(usersRoute?.variant.id).toBe('default');
+            expect(usersRoute?.variant.status).toBe(200);
+            expect(usersRoute?.variant.headers).toBeDefined();
+            expect(usersRoute?.variant.body).toBeDefined();
+        });
+    });
+
+    describe('HTTP method handling', () => {
+        /**
+         * Tests GET method parsing.
+         * @see example/mocker/consts.ts - HTTP_METHODS constant
+         * @see example/mocker/validation.ts - method field validation
+         */
+        it('should correctly identify GET routes', () => {
+            controller.useCollection('base');
+            const routes = controller.getActiveRoutes();
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            expect(usersRoute?.route.method).toBe(HttpMethod.Get);
+        });
+
+        /**
+         * Tests POST method parsing.
+         * @see example/mocker/consts.ts - HTTP_METHODS constant
+         */
+        it('should correctly identify POST routes', () => {
+            controller.useCollection('extended');
+            const routes = controller.getActiveRoutes();
+            const ordersRoute = routes.find(r => r.route.id === 'orders-api');
+
+            expect(ordersRoute?.route.method).toBe(HttpMethod.Post);
+        });
+    });
+
+    describe('collection inheritance behavior', () => {
+        /**
+         * Tests that child collection includes parent routes (from field).
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection with nesting"
+         * @see example/mocker/controller.ts - fillNestedRoutes method
+         */
+        it('should include parent routes in child collection', () => {
+            controller.useCollection('extended');
+            const routes = controller.getActiveRoutes();
+
+            // extended inherits from base which has products-api
+            const productsRoute = routes.find(r => r.route.id === 'products-api');
+            expect(productsRoute).toBeDefined();
+        });
+
+        /**
+         * Tests that child route overrides parent route with same id.
+         * @see example/mocker/controller.ts - fillNestedRoutes skips if identifier exists
+         */
+        it('should override parent route with same route id', () => {
+            controller.useCollection('override-parent');
+            const routes = controller.getActiveRoutes();
+
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+            // Child's variant should override parent's
+            expect(usersRoute?.variant.id).toBe('empty-list');
+        });
+
+        /**
+         * Tests multi-level inheritance (grandparent → parent → child).
+         * @see example/mocker/controller.ts - recursive fillNestedRoutes
+         */
+        it('should support multi-level inheritance', () => {
+            controller.useCollection('deeply-nested');
+            const routes = controller.getActiveRoutes();
+
+            // Should have routes from: base -> extended -> deeply-nested
+            const routeIds = routes.map(r => r.route.id);
+            expect(routeIds).toContain('products-api'); // from base
+            expect(routeIds).toContain('payments-api'); // from deeply-nested
+        });
+    });
+
+    describe('transport types', () => {
+        /**
+         * Tests HTTP transport identification.
+         * @see example/mocker/consts.ts - HTTP_METHODS vs WEBSOCKET_METHOD
+         */
+        it('should identify HTTP transport', () => {
+            controller.useCollection('base');
+            const routes = controller.getActiveRoutes();
+
+            routes.forEach(route => {
+                expect(route.route.transport).toBe(Transport.Http);
+            });
+        });
+
+        /**
+         * Tests WebSocket transport identification.
+         * @see example/mocker/consts.ts - WEBSOCKET_METHOD = 'WS'
+         */
+        it('should identify WebSocket transport', () => {
+            controller.useCollection('with-websocket');
+            const routes = controller.getActiveRoutes();
+
+            expect(routes[0]?.route.transport).toBe(Transport.WebSocket);
+        });
+    });
+
+    describe('error variant handling', () => {
+        /**
+         * Tests error response variants with status codes and body.
+         * @see example/mocker/validation.ts - Variant structure with status/body
+         */
+        it('should correctly parse error response variants', () => {
+            controller.useCollection('extended');
+            const routes = controller.getActiveRoutes();
+
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+            expect(usersRoute?.variant.status).toBe(404);
+
+            const body = usersRoute?.variant.body as {error: string; code: string};
+            expect(body.error).toBe('Users not found');
+            expect(body.code).toBe('NOT_FOUND');
+        });
+    });
+
+    /**
+     * Features from JS implementation that may not be implemented yet.
+     * These tests are marked as .todo and will be enabled when features are ready.
+     *
+     * @see example/mocker/__specs__/controller.spec.ts for original test cases
+     */
+    describe('TODO: features to implement', () => {
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected route for default collection"
+         */
+        it.todo('should allow switching individual routes without changing collection (useRoutes)');
+
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected route for default collection"
+         */
+        it.todo('should merge new routes with existing collection routes');
+
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if route is a websocket route"
+         */
+        it.todo('should support useSocket for WebSocket-only route switching');
+
+        /**
+         * @see example/mocker/controller.ts - getWebSocket method
+         */
+        it.todo('should provide getWebSocket method for WebSocket instance access');
+
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should restore mock to selected collection"
+         */
+        it.todo('should support resetRoutes to restore collection state');
+
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if collection have duplicated routes"
+         */
+        it.todo('should throw error for duplicated routes in collection');
+
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if collection with nesting not found"
+         */
+        it.todo('should throw error for non-existent parent collection (from field)');
+
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if route in collection not found"
+         */
+        it.todo('should throw error if route in collection not found');
+
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if preset in collection not found"
+         */
+        it.todo('should throw error if preset in collection not found');
+
+        /**
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if variant in collection not found"
+         */
+        it.todo('should throw error if variant in collection not found');
+    });
+});

--- a/packages/mockito-e2e-tests/__tests__/mocks-manager.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/mocks-manager.spec.ts
@@ -1,0 +1,279 @@
+/**
+ * E2E Tests for MocksManager (Rust implementation)
+ *
+ * These tests document expected behavior based on the original JS implementation.
+ * Some tests may fail if features are not yet implemented in Rust - this is expected
+ * and helps track implementation progress.
+ *
+ * MocksManager is stateless and resolves collections on-demand.
+ *
+ * @see example/mocker/__specs__/mocks.spec.ts for Mocks loader tests
+ * @see example/mocker/mocks.ts for Mocks class
+ * @see example/mocker/controller.ts for collection resolution logic
+ */
+import path from 'node:path';
+import {describe, expect, it, beforeAll} from '@rstest/core';
+import {MocksManager, Transport, HttpMethod} from '@mockito/binding';
+
+const FIXTURES_PATH = path.join(import.meta.dirname, '..', '__fixtures__');
+const COLLECTIONS_PATH = path.join(FIXTURES_PATH, 'collections.yaml');
+const ROUTES_PATH = path.join(FIXTURES_PATH, 'routes', '*.yaml');
+
+describe('MocksManager', () => {
+    let manager: MocksManager;
+
+    beforeAll(() => {
+        manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+    });
+
+    describe('resolveCollection', () => {
+        /**
+         * Tests basic collection resolution without inheritance.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection"
+         * @see example/mocker/controller.ts - useCollection method
+         */
+        it('should resolve base collection without inheritance', () => {
+            const routes = manager.resolveCollection('base');
+
+            expect(routes).toHaveLength(2);
+
+            const routeIds = routes.map(r => r.route.id);
+            expect(routeIds).toContain('users-api');
+            expect(routeIds).toContain('products-api');
+        });
+
+        /**
+         * Tests collection inheritance via 'from' field.
+         * @see example/mocker/__specs__/controller.spec.ts - "should mock selected collection with nesting"
+         * @see example/mocker/controller.ts - fillNestedRoutes method
+         */
+        it('should resolve collection with inheritance (from)', () => {
+            const routes = manager.resolveCollection('extended');
+
+            // extended inherits from base (2 routes) + adds 2 more
+            // users-api:error:not-found overrides users-api:success:default from base
+            expect(routes.length).toBeGreaterThanOrEqual(3);
+
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+            expect(usersRoute).toBeDefined();
+            expect(usersRoute?.preset.id).toBe('error');
+            expect(usersRoute?.variant.id).toBe('not-found');
+
+            const ordersRoute = routes.find(r => r.route.id === 'orders-api');
+            expect(ordersRoute).toBeDefined();
+            expect(ordersRoute?.preset.id).toBe('success');
+        });
+
+        /**
+         * Tests that child route overrides parent route with same route id.
+         * @see example/mocker/controller.ts - fillNestedRoutes: "if (map[identifier] === undefined)"
+         */
+        it('should override parent route with child route (same route id)', () => {
+            const routes = manager.resolveCollection('override-parent');
+
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+            expect(usersRoute).toBeDefined();
+            // Child overrides parent: success:empty-list instead of success:default
+            expect(usersRoute?.preset.id).toBe('success');
+            expect(usersRoute?.variant.id).toBe('empty-list');
+        });
+
+        /**
+         * Tests multi-level inheritance chain (grandparent → parent → child).
+         * @see example/mocker/controller.ts - recursive fillNestedRoutes call
+         */
+        it('should resolve deeply nested collections', () => {
+            const routes = manager.resolveCollection('deeply-nested');
+
+            // deeply-nested inherits from extended, which inherits from base
+            expect(routes.length).toBeGreaterThanOrEqual(4);
+
+            const paymentsRoute = routes.find(r => r.route.id === 'payments-api');
+            expect(paymentsRoute).toBeDefined();
+        });
+
+        /**
+         * Tests collection without 'from' field (no inheritance).
+         * @see example/mocker/controller.ts - fillNestedRoutes returns early if !collection.from
+         */
+        it('should resolve standalone collection without inheritance', () => {
+            const routes = manager.resolveCollection('standalone');
+
+            // Standalone has two routes with same route id but different presets
+            // Rust implementation deduplicates by route id + preset id combination
+            // Last one wins when same route id + preset id is used
+            expect(routes.length).toBeGreaterThanOrEqual(1);
+
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+            expect(usersRoute).toBeDefined();
+        });
+
+        /**
+         * Tests WebSocket route in collection.
+         * @see example/mocker/__specs__/controller.spec.ts - "should pass parser url for websocket route"
+         * @see example/mocker/consts.ts - WEBSOCKET_METHOD = 'WS'
+         */
+        it('should resolve collection with WebSocket routes', () => {
+            const routes = manager.resolveCollection('with-websocket');
+
+            expect(routes).toHaveLength(1);
+
+            const wsRoute = routes[0];
+            expect(wsRoute?.route.id).toBe('ws-notifications');
+            expect(wsRoute?.route.transport).toBe(Transport.WebSocket);
+        });
+
+        /**
+         * Tests error for non-existent collection.
+         * @see example/mocker/__specs__/controller.spec.ts - "should throw if no collection found"
+         */
+        it('should throw error for non-existent collection', () => {
+            expect(() => manager.resolveCollection('non-existent')).toThrow();
+        });
+    });
+
+    describe('ActiveRoute structure', () => {
+        /**
+         * Tests Route structure matches expected shape.
+         * @see example/mocker/validation.ts - Route type (ROUTE_SCHEMA)
+         */
+        it('should have correct route structure', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            expect(usersRoute).toBeDefined();
+            expect(usersRoute?.route).toMatchObject({
+                id: 'users-api',
+                url: '/api/users',
+                transport: Transport.Http,
+                method: HttpMethod.Get,
+            });
+        });
+
+        /**
+         * Tests Preset structure matches expected shape.
+         * @see example/mocker/validation.ts - Preset type (PRESET_SCHEMA)
+         */
+        it('should have correct preset structure', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            expect(usersRoute?.preset).toBeDefined();
+            expect(usersRoute?.preset.id).toBe('success');
+            expect(usersRoute?.preset.variants).toBeDefined();
+        });
+
+        /**
+         * Tests Variant structure with all fields.
+         * @see example/mocker/validation.ts - Variant type (VARIANT_SCHEMA)
+         */
+        it('should have correct variant structure', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            expect(usersRoute?.variant).toBeDefined();
+            expect(usersRoute?.variant.id).toBe('default');
+            expect(usersRoute?.variant.status).toBe(200);
+            expect(usersRoute?.variant.headers).toBeDefined();
+            expect(usersRoute?.variant.body).toBeDefined();
+        });
+
+        /**
+         * Tests body content preservation through parsing.
+         * @see example/mocker/__specs__/loader.spec.ts - YAML parsing tests
+         */
+        it('should have correct variant body content', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            const body = usersRoute?.variant.body as {data: Array<{id: number; name: string}>; total: number};
+            expect(body.data).toHaveLength(2);
+            expect(body.data[0]).toMatchObject({id: 1, name: 'John Doe'});
+            expect(body.total).toBe(2);
+        });
+    });
+
+    describe('HTTP methods', () => {
+        /**
+         * Tests GET method parsing from YAML.
+         * @see example/mocker/consts.ts - HTTP_METHODS = ['GET', 'POST', ...]
+         * @see example/mocker/validation.ts - method field oneOf validation
+         */
+        it('should correctly parse GET method', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            expect(usersRoute?.route.method).toBe(HttpMethod.Get);
+        });
+
+        /**
+         * Tests POST method parsing from YAML.
+         * @see example/mocker/consts.ts - HTTP_METHODS constant
+         */
+        it('should correctly parse POST method', () => {
+            const routes = manager.resolveCollection('extended');
+            const ordersRoute = routes.find(r => r.route.id === 'orders-api');
+
+            expect(ordersRoute?.route.method).toBe(HttpMethod.Post);
+        });
+    });
+
+    describe('preset matching conditions', () => {
+        /**
+         * Tests preset headers condition parsing.
+         * @see example/mocker/validation.ts - PRESET_SCHEMA headers field
+         * @see example/mocker/router/playwright-router.ts - header matching logic
+         */
+        it('should parse preset with headers condition', () => {
+            const routes = manager.resolveCollection('deeply-nested');
+            const paymentsRoute = routes.find(r => r.route.id === 'payments-api');
+
+            expect(paymentsRoute?.preset.headers).toBeDefined();
+        });
+
+        /**
+         * Tests preset payload condition parsing.
+         * @see example/mocker/validation.ts - PRESET_SCHEMA payload field
+         * @see example/mocker/router/playwright-router.ts - payload matching logic
+         */
+        it('should parse preset with payload condition', () => {
+            const routes = manager.resolveCollection('extended');
+            const ordersRoute = routes.find(r => r.route.id === 'orders-api');
+
+            expect(ordersRoute?.preset.payload).toBeDefined();
+        });
+    });
+
+    /**
+     * Features that may not be implemented yet.
+     * These tests are marked as .todo and will be enabled when features are ready.
+     *
+     * @see example/mocker/__specs__/validation.spec.ts for validation tests
+     * @see example/mocker/lib/ for utility functions
+     */
+    describe('TODO: features to implement', () => {
+        /**
+         * @see example/mocker/validation.ts - STRING_OR_NON_EMPTY_STRING_RECORD for query
+         * @see example/mocker/router/playwright-router.ts - query matching with expressions
+         */
+        it.todo('should support query parameter matching expressions');
+
+        /**
+         * @see example/mocker/lib/object-intersects.ts - JMESPath support
+         * @see example/mocker/router/playwright-router.ts - payload matching
+         */
+        it.todo('should support JMESPath expressions in payload matching');
+
+        /**
+         * @see example/mocker/lib/url-matches.ts - fillUrlWithParameters
+         * @see example/mocker/validation.ts - params field in preset
+         */
+        it.todo('should support URL path parameters (e.g., /users/:id)');
+
+        /**
+         * @see example/mocker/consts.ts - ALL_HTTP_METHODS = '*'
+         * @see example/mocker/validation.ts - method oneOf includes '*'
+         */
+        it.todo('should support wildcard HTTP method (*)');
+    });
+});

--- a/packages/mockito-e2e-tests/__tests__/response-body.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/response-body.spec.ts
@@ -1,0 +1,323 @@
+/**
+ * Response Body Tests
+ *
+ * Tests for different response body types and structures.
+ *
+ * @see example/mocker/validation.ts - body field in Variant
+ * @see example/mocker/__specs__/loader.spec.ts - YAML content preservation
+ */
+import path from 'node:path';
+import {describe, expect, it, beforeAll} from '@rstest/core';
+import {MocksManager} from '@mockito/binding';
+
+const FIXTURES_PATH = path.join(import.meta.dirname, '..', '__fixtures__');
+const COLLECTIONS_PATH = path.join(FIXTURES_PATH, 'collections.yaml');
+const ROUTES_PATH = path.join(FIXTURES_PATH, 'routes', '*.yaml');
+
+describe('Response Body', () => {
+    let manager: MocksManager;
+
+    beforeAll(() => {
+        manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+    });
+
+    describe('object body', () => {
+        /**
+         * Tests simple object body.
+         * @see example/mocker/__specs__/loader.spec.ts - object parsing
+         */
+        it('should preserve object body structure', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            const body = usersRoute?.variant.body as Record<string, unknown>;
+
+            expect(typeof body).toBe('object');
+            expect(body).not.toBeNull();
+        });
+
+        /**
+         * Tests nested object body.
+         * @see example/mocker/__specs__/loader.spec.ts - nested object parsing
+         */
+        it('should preserve nested object structure', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            const body = usersRoute?.variant.body as {
+                data: Array<{ id: number; name: string; email: string }>;
+                total: number;
+            };
+
+            expect(body.data).toBeDefined();
+            expect(body.data[0]).toHaveProperty('id');
+            expect(body.data[0]).toHaveProperty('name');
+            expect(body.data[0]).toHaveProperty('email');
+        });
+    });
+
+    describe('array body', () => {
+        /**
+         * Tests array in body.
+         * @see example/mocker/__specs__/loader.spec.ts - array parsing
+         */
+        it('should preserve array in body', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            const body = usersRoute?.variant.body as { data: unknown[] };
+
+            expect(Array.isArray(body.data)).toBe(true);
+            expect(body.data).toHaveLength(2);
+        });
+
+        /**
+         * Tests nested arrays.
+         * @see example/mocker/__specs__/loader.spec.ts - nested array parsing
+         */
+        it('should preserve nested array of objects', () => {
+            const routes = manager.resolveCollection('base');
+            const productsRoute = routes.find(r => r.route.id === 'products-api');
+
+            const body = productsRoute?.variant.body as {
+                products: Array<{ id: number; name: string; price: number }>;
+            };
+
+            expect(body.products).toHaveLength(2);
+            expect(body.products[0]).toMatchObject({
+                id: 1,
+                name: 'Product A',
+                price: 99.99,
+            });
+        });
+    });
+
+    describe('primitive values', () => {
+        /**
+         * Tests number values in body.
+         * @see example/mocker/__specs__/loader.spec.ts - number parsing
+         */
+        it('should preserve number values', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            const body = usersRoute?.variant.body as { total: number };
+
+            expect(typeof body.total).toBe('number');
+            expect(body.total).toBe(2);
+        });
+
+        /**
+         * Tests string values in body.
+         * @see example/mocker/__specs__/loader.spec.ts - string parsing
+         */
+        it('should preserve string values', () => {
+            const routes = manager.resolveCollection('base');
+            const usersRoute = routes.find(r => r.route.id === 'users-api');
+
+            const body = usersRoute?.variant.body as {
+                data: Array<{ name: string }>;
+            };
+
+            expect(typeof body.data[0].name).toBe('string');
+            expect(body.data[0].name).toBe('John Doe');
+        });
+
+        /**
+         * Tests boolean values in body.
+         * @see example/mocker/__specs__/loader.spec.ts - boolean parsing
+         */
+        it('should preserve boolean values', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const postRoute = routes.find(r => r.route.id === 'users-post');
+
+            const body = postRoute?.variant.body as { created: boolean };
+
+            expect(typeof body.created).toBe('boolean');
+            expect(body.created).toBe(true);
+        });
+
+        /**
+         * Tests float number values.
+         * @see example/mocker/__specs__/loader.spec.ts - float parsing
+         */
+        it('should preserve float values', () => {
+            const routes = manager.resolveCollection('base');
+            const productsRoute = routes.find(r => r.route.id === 'products-api');
+
+            const body = productsRoute?.variant.body as {
+                products: Array<{ price: number }>;
+            };
+
+            expect(body.products[0].price).toBe(99.99);
+            expect(body.products[1].price).toBe(149.99);
+        });
+    });
+
+    describe('error response body', () => {
+        /**
+         * Tests error object structure.
+         * @see example/mocker/validation.ts - error response body
+         */
+        it('should preserve error object', () => {
+            const routes = manager.resolveCollection('error-responses');
+            const route = routes.find(r => r.route.id === 'users-crud');
+
+            const body = route?.variant.body as {
+                error: string;
+                code: string;
+            };
+
+            expect(body.error).toBe('User not found');
+            expect(body.code).toBe('USER_NOT_FOUND');
+        });
+
+        /**
+         * Tests validation error with fields array.
+         * @see example/mocker/validation.ts - validation error body
+         */
+        it('should preserve validation error fields', () => {
+            const routes = manager.resolveCollection('error-responses');
+            const route = routes.find(r => r.route.id === 'users-post');
+
+            const body = route?.variant.body as {
+                error: string;
+                fields: Array<{ name: string } | string>;
+            };
+
+            expect(body.error).toBe('Validation failed');
+            expect(body.fields).toBeDefined();
+            expect(body.fields.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('special body structures', () => {
+        /**
+         * Tests auth response with token.
+         * @see example/mocker/validation.ts - auth response body
+         */
+        it('should preserve auth token response', () => {
+            const routes = manager.resolveCollection('auth-success');
+            const route = routes.find(r => r.route.id === 'auth-api');
+
+            const body = route?.variant.body as {
+                token: string;
+                expiresIn: number;
+            };
+
+            expect(body.token).toBe('jwt-token-here');
+            expect(body.expiresIn).toBe(3600);
+        });
+
+        /**
+         * Tests file upload response.
+         * @see example/mocker/validation.ts - file response body
+         */
+        it('should preserve file upload response', () => {
+            const routes = manager.resolveCollection('file-upload');
+            const route = routes.find(r => r.route.id === 'file-upload');
+
+            const body = route?.variant.body as {
+                fileId: string;
+                filename: string;
+                size: number;
+                url: string;
+            };
+
+            expect(body.fileId).toBe('file-123');
+            expect(body.filename).toBe('uploaded.pdf');
+            expect(body.size).toBe(1024);
+            expect(body.url).toBe('/files/file-123');
+        });
+
+        /**
+         * Tests search results with pagination.
+         * @see example/mocker/validation.ts - paginated response body
+         */
+        it('should preserve search results with pagination', () => {
+            const routes = manager.resolveCollection('search');
+            const route = routes.find(r => r.route.id === 'search-api');
+
+            const body = route?.variant.body as {
+                query: string;
+                page: number;
+                limit: number;
+                results: Array<{ id: number; title: string }>;
+                total: number;
+            };
+
+            expect(body.query).toBe('test');
+            expect(body.page).toBe(1);
+            expect(body.limit).toBe(10);
+            expect(body.results).toHaveLength(2);
+            expect(body.total).toBe(100);
+        });
+
+        /**
+         * Tests health check response.
+         * @see example/mocker/validation.ts - health response body
+         */
+        it('should preserve health check response', () => {
+            const routes = manager.resolveCollection('health');
+            const route = routes.find(r => r.route.id === 'health-check');
+
+            const body = route?.variant.body as {
+                status: string;
+                timestamp: string;
+            };
+
+            expect(body.status).toBe('ok');
+            expect(body.timestamp).toBe('2024-01-01T00:00:00Z');
+        });
+    });
+
+    describe('empty body', () => {
+        /**
+         * Tests response without body (204 No Content).
+         * @see example/mocker/validation.ts - optional body field
+         */
+        it('should handle response without body', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-delete');
+
+            // 204 responses typically don't have body
+            expect(route?.variant.status).toBe(204);
+        });
+    });
+
+    describe('empty array/object body', () => {
+        /**
+         * Tests empty results array.
+         * @see example/mocker/validation.ts - empty array body
+         */
+        it('should preserve empty array', () => {
+            const routes = manager.resolveCollection('search-empty');
+            const route = routes.find(r => r.route.id === 'search-api');
+
+            const body = route?.variant.body as {
+                results: unknown[];
+                total: number;
+            };
+
+            expect(body.results).toEqual([]);
+            expect(body.total).toBe(0);
+        });
+
+        /**
+         * Tests empty list response.
+         * @see example/mocker/validation.ts - empty data body
+         */
+        it('should preserve empty data list', () => {
+            const routes = manager.resolveCollection('override-parent');
+            const route = routes.find(r => r.route.id === 'users-api');
+
+            const body = route?.variant.body as {
+                data: unknown[];
+                total: number;
+            };
+
+            expect(body.data).toEqual([]);
+            expect(body.total).toBe(0);
+        });
+    });
+});

--- a/packages/mockito-e2e-tests/__tests__/url-patterns.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/url-patterns.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * URL Patterns Tests
+ *
+ * Tests for different URL patterns and path parameters.
+ *
+ * @see example/mocker/validation.ts - url field
+ * @see example/mocker/lib/url-matches.ts - URL matching utilities
+ */
+import path from 'node:path';
+import {describe, expect, it, beforeAll} from '@rstest/core';
+import {MocksManager} from '@mockito/binding';
+
+const FIXTURES_PATH = path.join(import.meta.dirname, '..', '__fixtures__');
+const COLLECTIONS_PATH = path.join(FIXTURES_PATH, 'collections.yaml');
+const ROUTES_PATH = path.join(FIXTURES_PATH, 'routes', '*.yaml');
+
+describe('URL Patterns', () => {
+    let manager: MocksManager;
+
+    beforeAll(() => {
+        manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+    });
+
+    describe('simple paths', () => {
+        /**
+         * Tests simple API path.
+         * @see example/mocker/validation.ts - url string field
+         */
+        it('should parse /api/users path', () => {
+            const routes = manager.resolveCollection('base');
+            const route = routes.find(r => r.route.id === 'users-api');
+
+            expect(route?.route.url).toBe('/api/users');
+        });
+
+        /**
+         * Tests another simple path.
+         * @see example/mocker/validation.ts - url string field
+         */
+        it('should parse /api/products path', () => {
+            const routes = manager.resolveCollection('base');
+            const route = routes.find(r => r.route.id === 'products-api');
+
+            expect(route?.route.url).toBe('/api/products');
+        });
+
+        /**
+         * Tests root-level path.
+         * @see example/mocker/validation.ts - url string field
+         */
+        it('should parse /health path', () => {
+            const routes = manager.resolveCollection('health');
+            const route = routes.find(r => r.route.id === 'health-check');
+
+            expect(route?.route.url).toBe('/health');
+        });
+    });
+
+    describe('paths with parameters', () => {
+        /**
+         * Tests path with :id parameter.
+         * @see example/mocker/lib/url-matches.ts - isTemplate, fillUrlWithParameters
+         */
+        it('should parse /api/users/:id path', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-crud');
+
+            expect(route?.route.url).toBe('/api/users/:id');
+        });
+
+        /**
+         * Tests PUT route with :id parameter.
+         * @see example/mocker/lib/url-matches.ts - URL parameters
+         */
+        it('should parse PUT /api/users/:id path', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-put');
+
+            expect(route?.route.url).toBe('/api/users/:id');
+        });
+
+        /**
+         * Tests PATCH route with :id parameter.
+         * @see example/mocker/lib/url-matches.ts - URL parameters
+         */
+        it('should parse PATCH /api/users/:id path', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-patch');
+
+            expect(route?.route.url).toBe('/api/users/:id');
+        });
+
+        /**
+         * Tests DELETE route with :id parameter.
+         * @see example/mocker/lib/url-matches.ts - URL parameters
+         */
+        it('should parse DELETE /api/users/:id path', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-delete');
+
+            expect(route?.route.url).toBe('/api/users/:id');
+        });
+    });
+
+    describe('nested paths', () => {
+        /**
+         * Tests nested path for auth.
+         * @see example/mocker/validation.ts - url string field
+         */
+        it('should parse /api/auth/login path', () => {
+            const routes = manager.resolveCollection('auth-success');
+            const route = routes.find(r => r.route.id === 'auth-api');
+
+            expect(route?.route.url).toBe('/api/auth/login');
+        });
+
+        /**
+         * Tests nested path for search.
+         * @see example/mocker/validation.ts - url string field
+         */
+        it('should parse /api/search path', () => {
+            const routes = manager.resolveCollection('search');
+            const route = routes.find(r => r.route.id === 'search-api');
+
+            expect(route?.route.url).toBe('/api/search');
+        });
+
+        /**
+         * Tests nested path for files.
+         * @see example/mocker/validation.ts - url string field
+         */
+        it('should parse /api/files path', () => {
+            const routes = manager.resolveCollection('file-upload');
+            const route = routes.find(r => r.route.id === 'file-upload');
+
+            expect(route?.route.url).toBe('/api/files');
+        });
+
+        /**
+         * Tests nested path for payments.
+         * @see example/mocker/validation.ts - url string field
+         */
+        it('should parse /api/payments path', () => {
+            const routes = manager.resolveCollection('deeply-nested');
+            const route = routes.find(r => r.route.id === 'payments-api');
+
+            expect(route?.route.url).toBe('/api/payments');
+        });
+    });
+
+    describe('WebSocket paths', () => {
+        /**
+         * Tests WebSocket notifications path.
+         * @see example/mocker/validation.ts - url for WS routes
+         */
+        it('should parse /ws/notifications path', () => {
+            const routes = manager.resolveCollection('with-websocket');
+            const route = routes.find(r => r.route.id === 'ws-notifications');
+
+            expect(route?.route.url).toBe('/ws/notifications');
+        });
+
+        /**
+         * Tests WebSocket chat path.
+         * @see example/mocker/validation.ts - url for WS routes
+         */
+        it('should parse /ws/chat path', () => {
+            const routes = manager.resolveCollection('ws-chat');
+            const route = routes.find(r => r.route.id === 'ws-chat');
+
+            expect(route?.route.url).toBe('/ws/chat');
+        });
+    });
+
+    describe('URL uniqueness across routes', () => {
+        /**
+         * Tests that different routes can have the same URL with different methods.
+         * @see example/mocker/validation.ts - route definition
+         */
+        it('should allow same URL with different methods', () => {
+            const routes = manager.resolveCollection('crud-operations');
+
+            const usersCrud = routes.find(r => r.route.id === 'users-crud');
+            const usersDelete = routes.find(r => r.route.id === 'users-delete');
+
+            // Both use /api/users/:id but different methods
+            expect(usersCrud?.route.url).toBe('/api/users/:id');
+            expect(usersDelete?.route.url).toBe('/api/users/:id');
+        });
+
+        /**
+         * Tests different URLs for POST routes.
+         * @see example/mocker/validation.ts - route definition
+         */
+        it('should have different URLs for different POST resources', () => {
+            const routes = manager.resolveCollection('crud-operations');
+
+            const usersPost = routes.find(r => r.route.id === 'users-post');
+
+            expect(usersPost?.route.url).toBe('/api/users');
+        });
+    });
+
+    describe('preset params matching URL params', () => {
+        /**
+         * Tests that preset params correspond to URL params.
+         * @see example/mocker/validation.ts - params in preset
+         */
+        it('should have preset params matching URL params', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-crud');
+
+            // URL has :id, preset has params.id
+            expect(route?.route.url).toContain(':id');
+            expect(route?.preset.params?.id).toBe('123');
+        });
+
+        /**
+         * Tests PUT route preset params.
+         * @see example/mocker/validation.ts - params in preset
+         */
+        it('should have PUT preset params', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-put');
+
+            expect(route?.preset.params?.id).toBe('123');
+        });
+
+        /**
+         * Tests PATCH route preset params.
+         * @see example/mocker/validation.ts - params in preset
+         */
+        it('should have PATCH preset params', () => {
+            const routes = manager.resolveCollection('crud-operations');
+            const route = routes.find(r => r.route.id === 'users-patch');
+
+            expect(route?.preset.params?.id).toBe('123');
+        });
+    });
+});

--- a/packages/mockito-e2e-tests/__tests__/version.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/version.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Version and API Tests
+ *
+ * Tests for binding version and API availability.
+ *
+ * @see bindings/node_binding/binding.d.ts - exported API
+ */
+import {describe, expect, it} from '@rstest/core';
+import {version, MocksManager, MocksController, HttpMethod, Transport} from '@mockito/binding';
+
+describe('Binding API', () => {
+    describe('version', () => {
+        /**
+         * Tests that version function is exported.
+         * @see bindings/node_binding/binding.d.ts - version export
+         */
+        it('should export version function', () => {
+            expect(typeof version).toBe('function');
+        });
+
+        /**
+         * Tests that version returns a string.
+         * @see bindings/node_binding/binding.d.ts - version(): string
+         */
+        it('should return version string', () => {
+            const v = version();
+            expect(typeof v).toBe('string');
+            expect(v.length).toBeGreaterThan(0);
+        });
+
+        /**
+         * Tests version format (semver-like).
+         * @see bindings/node_binding/package.json - version field
+         */
+        it('should return semver-like version', () => {
+            const v = version();
+            // Should contain at least one dot for semver
+            expect(v).toMatch(/^\d+\.\d+/);
+        });
+    });
+
+    describe('exports', () => {
+        /**
+         * Tests MocksManager class export.
+         * @see bindings/node_binding/binding.d.ts - MocksManager export
+         */
+        it('should export MocksManager class', () => {
+            expect(MocksManager).toBeDefined();
+            expect(typeof MocksManager).toBe('function');
+        });
+
+        /**
+         * Tests MocksController class export.
+         * @see bindings/node_binding/binding.d.ts - MocksController export
+         */
+        it('should export MocksController class', () => {
+            expect(MocksController).toBeDefined();
+            expect(typeof MocksController).toBe('function');
+        });
+
+        /**
+         * Tests HttpMethod enum export.
+         * @see bindings/node_binding/binding.d.ts - HttpMethod enum
+         */
+        it('should export HttpMethod enum', () => {
+            expect(HttpMethod).toBeDefined();
+            expect(HttpMethod.Get).toBe(0);
+            expect(HttpMethod.Post).toBe(1);
+            expect(HttpMethod.Put).toBe(2);
+            expect(HttpMethod.Patch).toBe(3);
+            expect(HttpMethod.Delete).toBe(4);
+            expect(HttpMethod.Head).toBe(5);
+            expect(HttpMethod.Options).toBe(6);
+        });
+
+        /**
+         * Tests Transport enum export.
+         * @see bindings/node_binding/binding.d.ts - Transport enum
+         */
+        it('should export Transport enum', () => {
+            expect(Transport).toBeDefined();
+            expect(Transport.Http).toBe(0);
+            expect(Transport.WebSocket).toBe(1);
+        });
+    });
+
+    describe('enum values', () => {
+        /**
+         * Tests all HTTP method enum values.
+         * @see example/mocker/consts.ts - HTTP_METHODS array
+         */
+        it('should have all HTTP methods', () => {
+            const methods = [
+                HttpMethod.Get,
+                HttpMethod.Post,
+                HttpMethod.Put,
+                HttpMethod.Patch,
+                HttpMethod.Delete,
+                HttpMethod.Head,
+                HttpMethod.Options,
+            ];
+
+            expect(methods).toHaveLength(7);
+            methods.forEach((method, index) => {
+                expect(method).toBe(index);
+            });
+        });
+
+        /**
+         * Tests all transport types.
+         * @see example/mocker/consts.ts - Transport types
+         */
+        it('should have all transport types', () => {
+            expect(Transport.Http).toBe(0);
+            expect(Transport.WebSocket).toBe(1);
+        });
+    });
+});

--- a/packages/mockito-e2e-tests/__tests__/websocket.spec.ts
+++ b/packages/mockito-e2e-tests/__tests__/websocket.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * WebSocket Routes Tests
+ *
+ * Tests for WebSocket transport support.
+ *
+ * @see example/mocker/consts.ts - WEBSOCKET_METHOD = 'WS'
+ * @see example/mocker/__specs__/controller.spec.ts - WebSocket tests
+ */
+import path from 'node:path';
+import {describe, expect, it, beforeAll} from '@rstest/core';
+import {MocksManager, MocksController, Transport} from '@mockito/binding';
+
+const FIXTURES_PATH = path.join(import.meta.dirname, '..', '__fixtures__');
+const COLLECTIONS_PATH = path.join(FIXTURES_PATH, 'collections.yaml');
+const ROUTES_PATH = path.join(FIXTURES_PATH, 'routes', '*.yaml');
+
+describe('WebSocket Routes', () => {
+    let manager: MocksManager;
+
+    beforeAll(() => {
+        manager = new MocksManager(COLLECTIONS_PATH, ROUTES_PATH);
+    });
+
+    describe('transport type', () => {
+        /**
+         * Tests WebSocket transport detection.
+         * @see example/mocker/consts.ts - WEBSOCKET_METHOD = 'WS'
+         */
+        it('should identify WebSocket transport', () => {
+            const routes = manager.resolveCollection('with-websocket');
+            const wsRoute = routes[0];
+
+            expect(wsRoute?.route.transport).toBe(Transport.WebSocket);
+        });
+
+        /**
+         * Tests that HTTP routes have HTTP transport.
+         * @see example/mocker/consts.ts - HTTP vs WS transport
+         */
+        it('should distinguish WebSocket from HTTP transport', () => {
+            const wsRoutes = manager.resolveCollection('with-websocket');
+            const httpRoutes = manager.resolveCollection('base');
+
+            expect(wsRoutes[0]?.route.transport).toBe(Transport.WebSocket);
+            expect(httpRoutes[0]?.route.transport).toBe(Transport.Http);
+        });
+    });
+
+    describe('WebSocket URL', () => {
+        /**
+         * Tests WebSocket URL parsing.
+         * @see example/mocker/validation.ts - url field
+         */
+        it('should parse WebSocket URL path', () => {
+            const routes = manager.resolveCollection('with-websocket');
+            const wsRoute = routes[0];
+
+            expect(wsRoute?.route.url).toBe('/ws/notifications');
+        });
+
+        /**
+         * Tests chat WebSocket URL.
+         * @see example/mocker/validation.ts - url field
+         */
+        it('should parse chat WebSocket URL', () => {
+            const routes = manager.resolveCollection('ws-chat');
+            const wsRoute = routes[0];
+
+            expect(wsRoute?.route.url).toBe('/ws/chat');
+        });
+    });
+
+    describe('WebSocket body', () => {
+        /**
+         * Tests WebSocket message body.
+         * @see example/mocker/validation.ts - body in Variant
+         */
+        it('should parse notification message body', () => {
+            const routes = manager.resolveCollection('with-websocket');
+            const wsRoute = routes[0];
+
+            const body = wsRoute?.variant.body as {
+                type: string;
+                payload: { title: string; content: string };
+            };
+
+            expect(body.type).toBe('notification');
+            expect(body.payload.title).toBe('New message');
+            expect(body.payload.content).toBe('Hello, world!');
+        });
+
+        /**
+         * Tests chat connected message.
+         * @see example/mocker/validation.ts - body in Variant
+         */
+        it('should parse chat connected message', () => {
+            const routes = manager.resolveCollection('ws-chat');
+            const wsRoute = routes[0];
+
+            const body = wsRoute?.variant.body as {
+                type: string;
+                userId: string;
+                room: string;
+            };
+
+            expect(body.type).toBe('connected');
+            expect(body.userId).toBe('user-123');
+            expect(body.room).toBe('general');
+        });
+
+        /**
+         * Tests chat message.
+         * @see example/mocker/validation.ts - body in Variant
+         */
+        it('should parse chat message', () => {
+            const routes = manager.resolveCollection('ws-chat-message');
+            const wsRoute = routes[0];
+
+            const body = wsRoute?.variant.body as {
+                type: string;
+                from: string;
+                text: string;
+                timestamp: string;
+            };
+
+            expect(body.type).toBe('message');
+            expect(body.from).toBe('user-456');
+            expect(body.text).toBe('Hello, World!');
+        });
+    });
+
+    describe('WebSocket with MocksController', () => {
+        /**
+         * Tests WebSocket routes via MocksController.
+         * @see example/mocker/__specs__/controller.spec.ts - "should pass parser url for websocket route"
+         */
+        it('should get WebSocket routes via controller', () => {
+            const controller = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+            controller.useCollection('with-websocket');
+
+            const routes = controller.getActiveRoutes();
+
+            expect(routes).toHaveLength(1);
+            expect(routes[0]?.route.transport).toBe(Transport.WebSocket);
+        });
+
+        /**
+         * Tests switching to WebSocket collection.
+         * @see example/mocker/controller.ts - useCollection
+         */
+        it('should switch to WebSocket collection', () => {
+            const controller = new MocksController(COLLECTIONS_PATH, ROUTES_PATH);
+
+            controller.useCollection('base');
+            expect(controller.getActiveRoutes()[0]?.route.transport).toBe(Transport.Http);
+
+            controller.useCollection('with-websocket');
+            expect(controller.getActiveRoutes()[0]?.route.transport).toBe(Transport.WebSocket);
+        });
+    });
+
+    describe('WebSocket method field', () => {
+        /**
+         * Tests that WebSocket routes don't have HTTP method.
+         * @see example/mocker/consts.ts - WS routes don't use HTTP method
+         */
+        it('should not have HTTP method for WebSocket route', () => {
+            const routes = manager.resolveCollection('with-websocket');
+            const wsRoute = routes[0];
+
+            // WebSocket routes typically don't have an HTTP method
+            // or it's undefined
+            expect(wsRoute?.route.method).toBeUndefined();
+        });
+    });
+
+    describe('multiple WebSocket variants', () => {
+        /**
+         * Tests switching between WebSocket variants via collections.
+         * @see example/mocker/controller.ts - variant selection
+         */
+        it('should support different WebSocket variants via collections', () => {
+            const connectedRoutes = manager.resolveCollection('ws-chat');
+            const messageRoutes = manager.resolveCollection('ws-chat-message');
+
+            const connectedBody = connectedRoutes[0]?.variant.body as { type: string };
+            const messageBody = messageRoutes[0]?.variant.body as { type: string };
+
+            expect(connectedBody.type).toBe('connected');
+            expect(messageBody.type).toBe('message');
+        });
+    });
+});

--- a/packages/mockito-e2e-tests/package.json
+++ b/packages/mockito-e2e-tests/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@mockito/e2e-tests",
+  "version": "0.1.0",
+  "private": true,
+  "description": "E2E tests comparing Rust implementation with expected behavior",
+  "type": "module",
+  "scripts": {
+    "test": "rstest run",
+    "test:watch": "rstest"
+  },
+  "devDependencies": {
+    "@rstest/core": "^0.8.0",
+    "@tsconfig/strictest": "^2.0.8",
+    "@types/node": "^22.0.0"
+  },
+  "dependencies": {
+    "@mockito/binding": "workspace:*"
+  }
+}

--- a/packages/mockito-e2e-tests/rstest.config.ts
+++ b/packages/mockito-e2e-tests/rstest.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from '@rstest/core';
+
+export default defineConfig({
+    include: ['__tests__/**/*.spec.ts'],
+    testTimeout: 10000,
+});

--- a/packages/mockito-e2e-tests/tsconfig.json
+++ b/packages/mockito-e2e-tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@tsconfig/strictest/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "isolatedModules": false,
+  },
+  "include": ["__tests__/**/*.ts", "rstest.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,47 +25,63 @@ importers:
         version: 5.9.3
 
   bindings/node_binding:
-    devDependencies:
-      '@napi-rs/cli':
-        specifier: ^3.5.1
-        version: 3.5.1(@emnapi/runtime@1.8.0)(@types/node@25.0.3)
     optionalDependencies:
-      '@mockito/binding-darwin-x64':
-        specifier: 0.1.0
-        version: link:./npm/darwin-x64
-      '@mockito/binding-win32-x64-msvc':
-        specifier: 0.1.0
-        version: link:./npm/win32-x64-msvc
-      '@mockito/binding-linux-x64-gnu':
-        specifier: 0.1.0
-        version: link:./npm/linux-x64-gnu
-      '@mockito/binding-linux-x64-musl':
-        specifier: 0.1.0
-        version: link:./npm/linux-x64-musl
-      '@mockito/binding-win32-ia32-msvc':
-        specifier: 0.1.0
-        version: link:./npm/win32-ia32-msvc
-      '@mockito/binding-linux-arm-gnueabihf':
-        specifier: 0.1.0
-        version: link:./npm/linux-arm-gnueabihf
       '@mockito/binding-darwin-arm64':
         specifier: 0.1.0
         version: link:./npm/darwin-arm64
+      '@mockito/binding-darwin-x64':
+        specifier: 0.1.0
+        version: link:./npm/darwin-x64
+      '@mockito/binding-linux-arm-gnueabihf':
+        specifier: 0.1.0
+        version: link:./npm/linux-arm-gnueabihf
       '@mockito/binding-linux-arm64-gnu':
         specifier: 0.1.0
         version: link:./npm/linux-arm64-gnu
       '@mockito/binding-linux-arm64-musl':
         specifier: 0.1.0
         version: link:./npm/linux-arm64-musl
+      '@mockito/binding-linux-x64-gnu':
+        specifier: 0.1.0
+        version: link:./npm/linux-x64-gnu
+      '@mockito/binding-linux-x64-musl':
+        specifier: 0.1.0
+        version: link:./npm/linux-x64-musl
       '@mockito/binding-win32-arm64-msvc':
         specifier: 0.1.0
         version: link:./npm/win32-arm64-msvc
+      '@mockito/binding-win32-ia32-msvc':
+        specifier: 0.1.0
+        version: link:./npm/win32-ia32-msvc
+      '@mockito/binding-win32-x64-msvc':
+        specifier: 0.1.0
+        version: link:./npm/win32-x64-msvc
+    devDependencies:
+      '@napi-rs/cli':
+        specifier: ^3.5.1
+        version: 3.5.1(@emnapi/runtime@1.8.0)(@types/node@25.0.3)
 
   packages/mockito-core:
     dependencies:
       '@mockito/binding':
         specifier: workspace:*
         version: link:../../bindings/node_binding
+
+  packages/mockito-e2e-tests:
+    dependencies:
+      '@mockito/binding':
+        specifier: workspace:*
+        version: link:../../bindings/node_binding
+    devDependencies:
+      '@rstest/core':
+        specifier: ^0.8.0
+        version: 0.8.0
+      '@tsconfig/strictest':
+        specifier: ^2.0.8
+        version: 2.0.8
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.7
 
 packages:
 
@@ -342,6 +358,24 @@ packages:
       '@types/node':
         optional: true
 
+  '@module-federation/error-codes@0.22.0':
+    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
+
+  '@module-federation/runtime-core@0.22.0':
+    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
+
+  '@module-federation/runtime-tools@0.22.0':
+    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
+
+  '@module-federation/runtime@0.22.0':
+    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
+
+  '@module-federation/sdk@0.22.0':
+    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
+
+  '@module-federation/webpack-bundler-runtime@0.22.0':
+    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
+
   '@napi-rs/cli@3.5.1':
     resolution: {integrity: sha512-XBfLQRDcB3qhu6bazdMJsecWW55kR85l5/k0af9BIBELXQSsCFU0fzug7PX8eQp6vVdm7W/U3z6uP5WmITB2Gw==}
     engines: {node: '>= 16'}
@@ -591,6 +625,9 @@ packages:
     resolution: {integrity: sha512-7cmzIu+Vbupriudo7UudoMRH2OA3cTw67vva8MxeoAe5S7vPFI7z0vp0pMXiA25S8IUJefImQ90FeJjl8fjEaQ==}
     engines: {node: '>= 10'}
 
+  '@napi-rs/wasm-runtime@1.0.7':
+    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
@@ -727,11 +764,108 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
+  '@rsbuild/core@1.7.2':
+    resolution: {integrity: sha512-VAFO6cM+cyg2ntxNW6g3tB2Jc5J5mpLjLluvm7VtW2uceNzyUlVv41o66Yp1t1ikxd3ljtqegViXem62JqzveA==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
+  '@rspack/binding-darwin-arm64@1.7.3':
+    resolution: {integrity: sha512-sXha3xG2KDkXLVjrmnw5kGhBriH2gFd9KAyD2ZBq0sH/gNIvqEaWhAFoO1YtrKU6rCgiSBrs0frfGc6DEqWfTA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.7.3':
+    resolution: {integrity: sha512-AUWMBgaPo7NgpW7arlw9laj9ZQxg7EjC5pnSCRH4BVPV+8egdoPCn5DZk05M25m73crKnGl8c7CrwTRNZeaPrw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@1.7.3':
+    resolution: {integrity: sha512-SodEX3+1/GLz0LobX9cY1QdjJ1NftSEh4C2vGpr71iA3MS9HyXuw4giqSeRQ4DpCybqpdS/3RLjVqFQEfGpcnw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.7.3':
+    resolution: {integrity: sha512-ydD2fNdEy+G7EYJ/a3FfdFZPfrLj/UnZocCNlZTTSHEhu+jURdQk0hwV11CvL+sjnKU5e/8IVMGUzhu3Gu8Ghg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-gnu@1.7.3':
+    resolution: {integrity: sha512-adnDbUqafSAI6/N6vZ+iONSo1W3yUpnNtJqP3rVp7+YdABhUpbOhtaY37qpIJ3uFajXctYFyISPrb4MWl1M9Yg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.7.3':
+    resolution: {integrity: sha512-5jnjdODk5HCUFPN6rTaFukynDU4Fn9eCL+4TSp6mqo6YAnfnJEuzDjfetA8t3aQFcAs7WriQfNwvdcA4HvYtbA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-wasm32-wasi@1.7.3':
+    resolution: {integrity: sha512-WLQK0ksUzMkVeGoHAMIxenmeEU5tMvFDK36Aip7VRj7T6vZTcAwvbMwc38QrIAvlG7dqWoxgPQi35ba1igNNDw==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@1.7.3':
+    resolution: {integrity: sha512-RAetPeY45g2NW6fID46VTV7mwY4Lqyw/flLbvCG28yrVOSkekw1KMCr1k335O3VNeqD+5dZDi1n+mwiAx/KMmA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.7.3':
+    resolution: {integrity: sha512-X3c1B609DxzW++FdWf7kkoXWwsC/DUEJ1N1qots4T0P2G2V+pDQfjdTRSC0YQ75toAvwZqpwGzToQJ9IwQ4Ayw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@1.7.3':
+    resolution: {integrity: sha512-f6AvZbJGIg+7NggHXv0+lyMzvIUfeCxcB5DNbo3H5AalIgwkoFpcBXLBqgMVIbqA0yNyP06eiK98rpzc9ulQQg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@1.7.3':
+    resolution: {integrity: sha512-N943pbPktJPymiYZWZMZMVX/PeSU42cWGpBly82N+ibNCX/Oo4yKWE0v+TyIJm5JaUFhtF2NpvzRbrjg/6skqw==}
+
+  '@rspack/core@1.7.3':
+    resolution: {integrity: sha512-GUiTRTz6+gbfM2g3ixXqrvPSeHmyAFu/qHEZZjbYFeDtZhpy1gVaVAHiZfaaIIm+vRlNi7JmULWFZQFKwpQB9Q==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/lite-tapable@1.1.0':
+    resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
+
+  '@rstest/core@0.8.0':
+    resolution: {integrity: sha512-zHpWPYN7T27YrtRwMM4dVm5PU1qQzAhX2ALspll1QT49BzuRHmJc2h3MaXTQ8F9k7sPMbhE+pGx9JQ7Vn7r+rQ==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+    peerDependencies:
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  '@swc/helpers@0.5.18':
+    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
+
+  '@tsconfig/strictest@2.0.8':
+    resolution: {integrity: sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/node@22.19.7':
+    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
 
   '@types/node@25.0.3':
     resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
@@ -764,6 +898,10 @@ packages:
 
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -817,6 +955,9 @@ packages:
     resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
     engines: {node: '>=16'}
     hasBin: true
+
+  core-js@3.47.0:
+    resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
 
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
@@ -1148,6 +1289,10 @@ packages:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1158,6 +1303,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -1483,6 +1631,31 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.3
 
+  '@module-federation/error-codes@0.22.0': {}
+
+  '@module-federation/runtime-core@0.22.0':
+    dependencies:
+      '@module-federation/error-codes': 0.22.0
+      '@module-federation/sdk': 0.22.0
+
+  '@module-federation/runtime-tools@0.22.0':
+    dependencies:
+      '@module-federation/runtime': 0.22.0
+      '@module-federation/webpack-bundler-runtime': 0.22.0
+
+  '@module-federation/runtime@0.22.0':
+    dependencies:
+      '@module-federation/error-codes': 0.22.0
+      '@module-federation/runtime-core': 0.22.0
+      '@module-federation/sdk': 0.22.0
+
+  '@module-federation/sdk@0.22.0': {}
+
+  '@module-federation/webpack-bundler-runtime@0.22.0':
+    dependencies:
+      '@module-federation/runtime': 0.22.0
+      '@module-federation/sdk': 0.22.0
+
   '@napi-rs/cli@3.5.1(@emnapi/runtime@1.8.0)(@types/node@25.0.3)':
     dependencies:
       '@inquirer/prompts': 8.1.0(@types/node@25.0.3)
@@ -1664,6 +1837,13 @@ snapshots:
       '@napi-rs/tar-win32-ia32-msvc': 1.1.0
       '@napi-rs/tar-win32-x64-msvc': 1.1.0
 
+  '@napi-rs/wasm-runtime@1.0.7':
+    dependencies:
+      '@emnapi/core': 1.8.0
+      '@emnapi/runtime': 1.8.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.8.0
@@ -1790,14 +1970,100 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@rsbuild/core@1.7.2':
+    dependencies:
+      '@rspack/core': 1.7.3(@swc/helpers@0.5.18)
+      '@rspack/lite-tapable': 1.1.0
+      '@swc/helpers': 0.5.18
+      core-js: 3.47.0
+      jiti: 2.6.1
+
+  '@rspack/binding-darwin-arm64@1.7.3':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.7.3':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@1.7.3':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.7.3':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@1.7.3':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.7.3':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@1.7.3':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.7.3':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@1.7.3':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.7.3':
+    optional: true
+
+  '@rspack/binding@1.7.3':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.7.3
+      '@rspack/binding-darwin-x64': 1.7.3
+      '@rspack/binding-linux-arm64-gnu': 1.7.3
+      '@rspack/binding-linux-arm64-musl': 1.7.3
+      '@rspack/binding-linux-x64-gnu': 1.7.3
+      '@rspack/binding-linux-x64-musl': 1.7.3
+      '@rspack/binding-wasm32-wasi': 1.7.3
+      '@rspack/binding-win32-arm64-msvc': 1.7.3
+      '@rspack/binding-win32-ia32-msvc': 1.7.3
+      '@rspack/binding-win32-x64-msvc': 1.7.3
+
+  '@rspack/core@1.7.3(@swc/helpers@0.5.18)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.22.0
+      '@rspack/binding': 1.7.3
+      '@rspack/lite-tapable': 1.1.0
+    optionalDependencies:
+      '@swc/helpers': 0.5.18
+
+  '@rspack/lite-tapable@1.1.0': {}
+
+  '@rstest/core@0.8.0':
+    dependencies:
+      '@rsbuild/core': 1.7.2
+      '@types/chai': 5.2.3
+      tinypool: 1.1.1
+
+  '@swc/helpers@0.5.18':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tsconfig/strictest@2.0.8': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
-      '@types/node': 25.0.3
+      '@types/node': 22.19.7
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/node@22.19.7':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@25.0.3':
     dependencies:
@@ -1828,6 +2094,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-ify@1.0.0: {}
+
+  assertion-error@2.0.1: {}
 
   before-after-hook@4.0.0: {}
 
@@ -1876,6 +2144,8 @@ snapshots:
       is-text-path: 2.0.0
       meow: 12.1.1
       split2: 4.2.0
+
+  core-js@3.47.0: {}
 
   cosmiconfig-typescript-loader@6.2.0(@types/node@25.0.3)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
@@ -2124,12 +2394,15 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
-  tslib@2.8.1:
-    optional: true
+  tinypool@1.1.1: {}
+
+  tslib@2.8.1: {}
 
   typanion@3.14.0: {}
 
   typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 
@@ -2164,23 +2437,3 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@1.2.2: {}
-
-  '@mockito/binding-darwin-x64@0.1.0': {}
-
-  '@mockito/binding-win32-x64-msvc@0.1.0': {}
-
-  '@mockito/binding-linux-x64-gnu@0.1.0': {}
-
-  '@mockito/binding-linux-x64-musl@0.1.0': {}
-
-  '@mockito/binding-win32-ia32-msvc@0.1.0': {}
-
-  '@mockito/binding-linux-arm-gnueabihf@0.1.0': {}
-
-  '@mockito/binding-darwin-arm64@0.1.0': {}
-
-  '@mockito/binding-linux-arm64-gnu@0.1.0': {}
-
-  '@mockito/binding-linux-arm64-musl@0.1.0': {}
-
-  '@mockito/binding-win32-arm64-msvc@0.1.0': {}


### PR DESCRIPTION
- Add mockito-e2e-tests package with comprehensive test suite
- Include fixtures for various API scenarios (CRUD, auth, websocket, etc.)
- Add tests for HTTP methods, URL patterns, response bodies, edge cases
- Add mocks controller and manager tests
- Add collection inheritance and version tests
- Remove --const-enum flag from napi build commands